### PR TITLE
Add user variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.0] - 2024-01-28
+
+- Added `user` to `Hass` interface
+- New properties to get user data (`user_name`, `user_is_admin`, `user_is_owner`)
+- Add `strict mode` to the compiled code
+
 ## [1.0.1] - 2024-01-28
 
 - Exports the `Hass` interface

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A JavaScript utility to render Home Assistant JavaScript templates.
 
-[![Deployment Status](https://github.com/elchininet/home-assistant-javascript-templates/actions/workflows/deploy.yaml/badge.svg)](https://github.com/elchininet/home-assistant-javascript-templates/actions/workflows/deploy.yaml) &nbsp; [![Coverage Status](https://coveralls.io/repos/github/elchininet/home-assistant-javascript-templates/badge.svg?branch=master)](https://coveralls.io/github/elchininet/home-assistant-javascript-templates?branch=master) &nbsp; [![npm version](https://badge.fury.io/js/home-assistant-javascript-templates.svg)](https://badge.fury.io/js/home-assistant-javascript-templates)
+[![Deployment Status](https://github.com/elchininet/home-assistant-javascript-templates/actions/workflows/deploy.yaml/badge.svg)](https://github.com/elchininet/home-assistant-javascript-templates/actions/workflows/deploy.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/elchininet/home-assistant-javascript-templates/badge.svg?branch=master)](https://coveralls.io/github/elchininet/home-assistant-javascript-templates?branch=master)
+[![npm version](https://badge.fury.io/js/home-assistant-javascript-templates.svg)](https://badge.fury.io/js/home-assistant-javascript-templates)
 
 ## Install
 
@@ -191,7 +193,33 @@ area_devices('woonkamer')
 area_devices('Woonkamer')
 ```
 
-## Example
+#### user_name
+
+Property to return the name of the user logged in in Home Assistant. It returns a `string`.
+
+```javascript
+user_name
+```
+
+#### user_is_admin
+
+Property to return if the user logged in in Home Assistant is admin or not. It returns a `boolean`.
+
+```javascript
+user_is_admin
+```
+
+#### user_is_owner
+
+Property to return if the user logged in in Home Assistant is the owner. It returns a `boolean`.
+
+```javascript
+user_is_owner
+```
+
+## Examples
+
+#### Get a device attribute and return a formatted text with it
 
 ```javascript
 import HomeAssistantJavaScriptTemplates  from 'home-assistant-javascript-templates';
@@ -210,5 +238,21 @@ renderer.renderTemplate(`
     const deviceId = device_id("binary_sensor.koffiezetapparaat_aan");
     const serialNumber = device_attr(deviceId, "serial_number");
     return "sn:" + serialNumber;
+`);
+```
+
+#### Get all the available updates
+
+```javascript
+import HomeAssistantJavaScriptTemplates  from 'home-assistant-javascript-templates';
+
+const renderer = new HomeAssistantJavaScriptTemplates(
+    document.querySelector('home-assistant').hass
+);
+
+renderer.renderTemplate(`
+    const udatesEntities = states['update'];
+    const updatesEntitiesOn = udatesEntities?.filter((entity) => entity.state === 'on');
+    return updatesEntitiesOn?.length || 0;
 `);
 ```

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,3 +9,4 @@ export enum ATTRIBUTES {
 }
 
 export const NONE = 'None';
+export const STRICT_MODE = '"use strict";';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Hass, Scopped } from '@types';
+import { STRICT_MODE } from '@constants';
 import { createScoppedFunctions } from '@utilities';
 
 export default class HomeAssistantJavaScriptTemplates {
@@ -32,7 +33,10 @@ export default class HomeAssistantJavaScriptTemplates {
             'area_name',
             'area_entities',
             'area_devices',
-            functionBody
+            'user_name',
+            'user_is_admin',
+            'user_is_owner',
+            `${STRICT_MODE} ${functionBody}`
         );
 
         try {
@@ -51,7 +55,10 @@ export default class HomeAssistantJavaScriptTemplates {
                 this._scopped.area_id.bind(this._scopped),
                 this._scopped.area_name.bind(this._scopped),
                 this._scopped.area_entities.bind(this._scopped),
-                this._scopped.area_devices.bind(this._scopped)
+                this._scopped.area_devices.bind(this._scopped),
+                this._scopped.user_name,
+                this._scopped.user_is_admin,
+                this._scopped.user_is_owner
             );
 
         } catch (error) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,11 +20,18 @@ export interface Entity {
     device_id: string;
 }
 
+export interface User {
+    name: string;
+    is_admin: boolean;
+    is_owner: boolean;
+}
+
 export interface Hass {
     areas: Record<string, Area>;
     devices: Record<string, Device>;
     entities: Record<string, Entity>;
     states: Record<string, State>;
+    user: User;
 }
 
 export interface ProxiedStates {
@@ -49,4 +56,7 @@ export interface Scopped {
     area_name: (lookupValue: string) => string | undefined;
     area_entities: (lookupValue: string) => string[];
     area_devices: (lookupValue: string) => string[];
+    user_name: string;
+    user_is_admin: boolean;
+    user_is_owner: boolean;
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -143,6 +143,9 @@ export function createScoppedFunctions(hass: Hass): Scopped {
                     });
             }
             return [];
-        }
+        },
+        user_name: hass.user.name,
+        user_is_admin: hass.user.is_admin,
+        user_is_owner: hass.user.is_owner
     };
 }

--- a/tests/basic-templates.test.ts
+++ b/tests/basic-templates.test.ts
@@ -285,4 +285,20 @@ describe('Basic templates tests', () => {
 
     });
 
+    it('user_name, user_is_admin, user_is_owner', () => {
+
+        expect(
+            compiler.renderTemplate('user_name')
+        ).toBe('ElChiniNet');
+
+        expect(
+            compiler.renderTemplate('user_is_admin')
+        ).toBe(true);
+
+        expect(
+            compiler.renderTemplate('user_is_owner')
+        ).toBe(false);
+
+    });
+
 });

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -151,5 +151,10 @@ export const HASS: Hass = {
             entity_id: 'camera.keukencamera',
             state: 'unavailable'
         }
+    },
+    user: {
+        is_admin: true,
+        is_owner: false,
+        name: 'ElChiniNet'
     }
 };


### PR DESCRIPTION
This pull request adds new variables to get user information.

#### user_name

Property to return the name of the user logged in in Home Assistant. It returns a `string`.

```javascript
user_name
```

#### user_is_admin

Property to return if the user logged in in Home Assistant is admin or not. It returns a `boolean`.

```javascript
user_is_admin
```

#### user_is_owner

Property to return if the user logged in in Home Assistant is the owner. It returns a `boolean`.

```javascript
user_is_owner
```