### PR TITLE
Remove None returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.0] - 2024-01-28
+
+- Rollback the `None` returns and return `undefined` in these cases.
+
 ## [1.1.0] - 2024-01-28
 
 - Added `user` to `Hass` interface

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ is_state('device_tracker.paulus', 'not_home')
 
 #### state_attr
 
-Method to return the value of the state attribute or `None` if it doesn’t exist.
+Method to return the value of the state attribute or `undefined` if it doesn’t exist.
 
 ```javascript
 state_attr('device_tracker.paulus', 'battery')
@@ -125,7 +125,7 @@ has_value('sensor.my_sensor')
 
 #### device_attr
 
-Method that returns the value of an attribute for the given device id or `None` if it doesn’t exist.
+Method that returns the value of an attribute for the given device id or `undefined` if it doesn’t exist.
 
 ```javascript
 device_attr('706ad0ebe27e105d7cd0b73386deefdd')
@@ -141,7 +141,7 @@ is_device_attr('706ad0ebe27e105d7cd0b73386deefdd', 'manufacturer', 'Synology')
 
 #### device_id
 
-Method to return the device id for a given entity id or `None` if the entity doesn‘t exist. 
+Method to return the device id for a given entity id or `undefined` if the entity doesn‘t exist. 
 
 ```javascript
 device_id('sensor.my_sensor')
@@ -157,7 +157,7 @@ areas()
 
 #### area_id
 
-Method to return the area id for a given device id, entity id, or area name. It returns `None` if the area doesn‘t exist.
+Method to return the area id for a given device id, entity id, or area name. It returns `undefined` if the area doesn‘t exist.
 
 ```javascript
 area_id('b8c1c9dd23cb82bbfa09b5657f41d04f')
@@ -167,7 +167,7 @@ area_id('Woonkamer')
 
 #### area_name
 
-Method to return the area name for a given device id, entity id, or area id. It returns `None` if the area doesn‘t exist.
+Method to return the area name for a given device id, entity id, or area id. It returns `undefined` if the area doesn‘t exist.
 
 ```javascript
 area_name('b8c1c9dd23cb82bbfa09b5657f41d04f')

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -8,5 +8,4 @@ export enum ATTRIBUTES {
     NAME = 'name'
 }
 
-export const NONE = 'None';
 export const STRICT_MODE = '"use strict";';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,8 +39,6 @@ export interface ProxiedStates {
     [entityId: string]: State[] | State | undefined;
 }
 
-export type None = 'None';
-
 export interface Scopped {
     hass: Hass;
     states: ProxiedStates;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -2,14 +2,9 @@ import {
     Hass,
     State,
     ProxiedStates,
-    Scopped,
-    None
+    Scopped
 } from '@types';
-import {
-    STATE_VALUES,
-    ATTRIBUTES,
-    NONE
-} from '@constants';
+import { STATE_VALUES, ATTRIBUTES } from '@constants';
 
 const arrayFromEntries = <T = unknown>(entries: [string, T][]): T[] => {
     return entries.reduce((acc: T[], entry: [string, T]): T[] => {
@@ -47,8 +42,8 @@ export function createScoppedFunctions(hass: Hass): Scopped {
         is_state(entityId: string, value: string): boolean {
             return hass.states[entityId]?.state === value;
         },
-        state_attr(entityId: string, attr: string): unknown | None {
-            return hass.states[entityId]?.attributes?.[attr] || NONE;
+        state_attr(entityId: string, attr: string): unknown {
+            return hass.states[entityId]?.attributes?.[attr];
         },
         is_state_attr(entityId: string, attr: string, value: unknown): boolean {
             return this.state_attr(entityId, attr) === value;
@@ -64,14 +59,14 @@ export function createScoppedFunctions(hass: Hass): Scopped {
         },
 
         // ---------------------- Devices
-        device_attr(deviceId: string, attr: string): unknown | None {
-            return hass.devices[deviceId]?.[attr] || NONE;
+        device_attr(deviceId: string, attr: string): unknown {
+            return hass.devices[deviceId]?.[attr];
         },
         is_device_attr(deviceId: string, attr: string, value: unknown): boolean {
             return this.device_attr(deviceId, attr) === value;
         },
-        device_id(entityId: string): string | None {
-            return hass.entities[entityId]?.device_id || NONE;
+        device_id(entityId: string): string {
+            return hass.entities[entityId]?.device_id;
         },
         
         // ---------------------- Areas
@@ -80,24 +75,24 @@ export function createScoppedFunctions(hass: Hass): Scopped {
                 return area.area_id;
             });
         },
-        area_id(lookupValue: string): string | None {
+        area_id(lookupValue: string): string | undefined {
             if (lookupValue in hass.devices) {
                 return this.device_attr(lookupValue, ATTRIBUTES.AREA_ID);
             }
             const deviceId = this.device_id(lookupValue);
-            if (deviceId && deviceId !== NONE) {
+            if (deviceId) {
                 return this.device_attr(deviceId, ATTRIBUTES.AREA_ID);
             }
             const area = areasEntries.find(([, area]) => area.name === lookupValue);
-            return area?.[1]?.area_id || NONE;
+            return area?.[1]?.area_id;
         },
-        area_name(lookupValue: string): string | None {
+        area_name(lookupValue: string): string | undefined {
             let areaId: string;
             if (lookupValue in hass.devices) {
                 areaId = this.device_attr(lookupValue, ATTRIBUTES.AREA_ID);
             }
             const deviceId = this.device_id(lookupValue);
-            if (deviceId && deviceId !== NONE) {
+            if (deviceId) {
                 areaId = this.device_attr(deviceId, ATTRIBUTES.AREA_ID);
             }
             const area = areasEntries.find(([, area]) => {
@@ -106,7 +101,7 @@ export function createScoppedFunctions(hass: Hass): Scopped {
                     area.area_id === areaId
                 );
             });
-            return area?.[1]?.name || NONE;
+            return area?.[1]?.name;
         },
         area_entities(lookupValue: string): string[] {
             const areaFound = areasEntries.find(([, area]) => {

--- a/tests/basic-templates.test.ts
+++ b/tests/basic-templates.test.ts
@@ -1,5 +1,4 @@
 import HomeAssistantJavaScriptTemplates from '../src';
-import { NONE } from '../src/constants';
 import { HASS } from './constants';
 
 describe('Basic templates tests', () => {
@@ -89,7 +88,7 @@ describe('Basic templates tests', () => {
 
         expect(
             compiler.renderTemplate('state_attr("sensor.non_existent", "device_class")')
-        ).toBe(NONE);
+        ).toBe(undefined);
 
     });
 
@@ -141,11 +140,11 @@ describe('Basic templates tests', () => {
 
         expect(
             compiler.renderTemplate('device_attr("b8c1c9dd23cb82bbfa09b5657f41d04f", "attr")')
-        ).toBe(NONE);
+        ).toBe(undefined);
 
         expect(
             compiler.renderTemplate('device_attr("012345", "attr")')
-        ).toBe(NONE);
+        ).toBe(undefined);
 
     });
 
@@ -181,7 +180,7 @@ describe('Basic templates tests', () => {
 
         expect(
             compiler.renderTemplate('device_id("sensor.non_existent")')
-        ).toBe(NONE);
+        ).toBe(undefined);
 
     });
 
@@ -217,7 +216,7 @@ describe('Basic templates tests', () => {
 
         expect(
             compiler.renderTemplate('area_id("NonExistent")')
-        ).toBe(NONE);
+        ).toBe(undefined);
 
     });
 
@@ -237,7 +236,7 @@ describe('Basic templates tests', () => {
 
         expect(
             compiler.renderTemplate('area_name("non_existent")')
-        ).toBe(NONE);
+        ).toBe(undefined);
 
     });
 


### PR DESCRIPTION
This pull request rollback the `None` returns of the methods and replace them by `underfined` something that makes more sense in `JavaScript`.