### PR TITLE
Throw an error if the states function is used with a domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.2.0] - 2024-01-28
 
 - Rollback the `None` returns and return `undefined` in these cases.
+- Throw an error if the `states` method is used with a domain
 
 ## [1.1.0] - 2024-01-28
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ new HomeAssistantJavaScriptTemplates(hass, throwErrors = false);
 | Parameter     | Optional      | Description                                        |
 | ------------- | ------------- | -------------------------------------------------- |
 | `hass`        | no            | A valid `hass` object                              |
-| `throwErrors` | yes           | Indicates if the library should throw if the template contains any error. If not it will log the errors as a warning in the console. |
+| `throwErrors` | yes           | Indicates if the library should throw if the template contains any error. If not it will log the errors as a warning in the console and return `undefined` instead. |
 
 ### renderTemplate method
 
@@ -81,14 +81,17 @@ The same `hass` object that was sent to the class
 
 #### states
 
-States could be used in two ways, as a function or as an object.
+`states` could be used in two ways, as a function or as an object. When using it as function it only allows an entity id as a parameter and it will return the state of that entity. When using it as an object, you can use also an entity id but in those cases it will return the entire state object, so you need to access its `state` property to get the state value. When using it as an object with a domain, it will return an array with all the states of that domain.
+
+>Note: If you try to use `states` as a function sending a domain it will throw an error.
 
 ```javascript
 // Using states as a function
-states('device_tracker.paulus')
+states('device_tracker.paulus') // returns the state of the entity id 'device_tracker.paulus'
 
 // Using states as an object
-states['device_tracker.paulus'].state
+states['device_tracker.paulus'].state // returns the state of the entity id 'device_tracker.paulus'
+states['device_tracker'] // returns an array with all the states of the 'device_tracker' domain
 ```
 
 #### is_state

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -25,7 +25,12 @@ export function createScoppedFunctions(hass: Hass): Scopped {
         hass,
         // ---------------------- States
         states: new Proxy(
-            (entityId: string): string | undefined => hass.states[entityId]?.state, 
+            (entityId: string): string | undefined => {
+                if (entityId.includes('.')) {
+                    return hass.states[entityId]?.state
+                }
+                throw SyntaxError('[home-assistant-javascript-templates]: states method cannot be used with a domain, use it as an object instead.');
+            }, 
             {
                 get(__target, entityId: string): State[] | State | undefined {
                     if (entityId.includes('.')) {

--- a/tests/basic-templates.test.ts
+++ b/tests/basic-templates.test.ts
@@ -54,9 +54,9 @@ describe('Basic templates tests', () => {
             ]
         );
 
-        // expect(
-        //     compiler.renderTemplate('states["battery"]')
-        // ).toBe(undefined);
+        expect(
+            compiler.renderTemplate('states["battery"]')
+        ).toMatchObject([]);
 
     });
 

--- a/tests/error-templates.test.ts
+++ b/tests/error-templates.test.ts
@@ -5,7 +5,7 @@ describe('Templates with errors', () => {
 
     const errorMessage = 'states.binary_sensor.koffiezetapparaat_verbonden.state.toFixed is not a function';
 
-    it('TypeError as a console log', () => {
+    it('Error as a console log', () => {
 
         const compiler = new HomeAssistantJavaScriptTemplates(HASS);
         const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
@@ -20,13 +20,17 @@ describe('Templates with errors', () => {
 
     });
 
-    it('TypeError as an error', () => {
+    it('Error as an error', () => {
 
         const compiler = new HomeAssistantJavaScriptTemplates(HASS, true);
 
         expect(
             () => compiler.renderTemplate('states["binary_sensor.koffiezetapparaat_verbonden"].state.toFixed(16)')
         ).toThrow(errorMessage);
+
+        expect(
+            () => compiler.renderTemplate('states("battery")')
+        ).toThrow('states method cannot be used with a domain, use it as an object instead');
 
     });
 


### PR DESCRIPTION
This pull request implements an error throwing if the `states` function is used with a domain instaed of an entity id.