### PR TITLE
[BREAKING CHANGE] The class needs an HTMLElement isntead of a hass object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.0] - 2024-01-28
+
+[BREAKING CHANGE]:
+    - The main class doesn‘t accept a `hass` object anymore. It needs an HTML element that contains the `hass` object as a property. This is to solve a bug that the templates were returining always the old version of the states.
+
 ## [1.2.0] - 2024-01-28
 
 - Rollback the `None` returns and return `undefined` in these cases.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pnpm add home-assistant-javascript-templates
 const HomeAssistantJavaScriptTemplates = require('home-assistant-javascript-templates');
 
 const renderer = new HomeAssistantJavaScriptTemplates(
-    document.querySelector('home-assistant').hass
+    document.querySelector('home-assistant')
 );
 
 renderer.renderTemplate('... template string ...');
@@ -46,7 +46,7 @@ renderer.renderTemplate('... template string ...');
 import HomeAssistantJavaScriptTemplates  from 'home-assistant-javascript-templates';
 
 const renderer = new HomeAssistantJavaScriptTemplates(
-    document.querySelector('home-assistant').hass
+    document.querySelector('home-assistant')
 );
 
 renderer.renderTemplate('... template string ...');
@@ -61,12 +61,12 @@ The package exposes a class that needs to be instantiated and is this isntance t
 Main class of the library, it is the `default` export in the package.
 
 ```typescript
-new HomeAssistantJavaScriptTemplates(hass, throwErrors = false);
+new HomeAssistantJavaScriptTemplates(ha, throwErrors = false);
 ```
 
 | Parameter     | Optional      | Description                                        |
 | ------------- | ------------- | -------------------------------------------------- |
-| `hass`        | no            | A valid `hass` object                              |
+| `ha`          | no            | An HTML element that has the `hass` object as a property (e.g. the `home-assistant` custom element). |
 | `throwErrors` | yes           | Indicates if the library should throw if the template contains any error. If not it will log the errors as a warning in the console and return `undefined` instead. |
 
 ### renderTemplate method
@@ -77,7 +77,7 @@ This is the main method to render `JavaScript` templates, it needs a string as a
 
 #### hass
 
-The same `hass` object that was sent to the class
+The `hass` object
 
 #### states
 
@@ -228,7 +228,7 @@ user_is_owner
 import HomeAssistantJavaScriptTemplates  from 'home-assistant-javascript-templates';
 
 const renderer = new HomeAssistantJavaScriptTemplates(
-    document.querySelector('home-assistant').hass
+    document.querySelector('home-assistant')
 );
 
 /**
@@ -250,7 +250,7 @@ renderer.renderTemplate(`
 import HomeAssistantJavaScriptTemplates  from 'home-assistant-javascript-templates';
 
 const renderer = new HomeAssistantJavaScriptTemplates(
-    document.querySelector('home-assistant').hass
+    document.querySelector('home-assistant')
 );
 
 renderer.renderTemplate(`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,15 @@
-import { Hass, Scopped } from '@types';
+import {
+    HomeAssistant,
+    Hass,
+    Scopped
+} from '@types';
 import { STRICT_MODE } from '@constants';
 import { createScoppedFunctions } from '@utilities';
 
 export default class HomeAssistantJavaScriptTemplates {
 
-    constructor(hass: Hass, throwErrors = false) {
-        this._scopped = createScoppedFunctions(hass);
+    constructor(ha: HomeAssistant, throwErrors = false) {
+        this._scopped = createScoppedFunctions(ha);
         this._errors = throwErrors;
     }
 
@@ -73,4 +77,4 @@ export default class HomeAssistantJavaScriptTemplates {
     }
 }
 
-export { Hass };
+export { HomeAssistant, Hass };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,10 @@ export interface Hass {
     user: User;
 }
 
+export interface HomeAssistant extends HTMLElement {
+	hass: Hass;
+}
+
 export interface ProxiedStates {
     (entityId: string): string | undefined;
     [entityId: string]: State[] | State | undefined;

--- a/tests/basic-templates.test.ts
+++ b/tests/basic-templates.test.ts
@@ -1,13 +1,12 @@
 import HomeAssistantJavaScriptTemplates from '../src';
-import { HomeAssistant } from '../src/types';
-import { HASS } from './constants';
+import { HOME_ASSISTANT_ELEMENT, HASS } from './constants';
 
 describe('Basic templates tests', () => {
 
     let compiler: HomeAssistantJavaScriptTemplates;
     
     beforeEach(() => {
-        compiler = new HomeAssistantJavaScriptTemplates({ hass: HASS } as HomeAssistant);
+        compiler = new HomeAssistantJavaScriptTemplates(HOME_ASSISTANT_ELEMENT);
     });
 
     it('hass', () => {

--- a/tests/basic-templates.test.ts
+++ b/tests/basic-templates.test.ts
@@ -1,4 +1,5 @@
 import HomeAssistantJavaScriptTemplates from '../src';
+import { HomeAssistant } from '../src/types';
 import { HASS } from './constants';
 
 describe('Basic templates tests', () => {
@@ -6,7 +7,7 @@ describe('Basic templates tests', () => {
     let compiler: HomeAssistantJavaScriptTemplates;
     
     beforeEach(() => {
-        compiler = new HomeAssistantJavaScriptTemplates(HASS);
+        compiler = new HomeAssistantJavaScriptTemplates({ hass: HASS } as HomeAssistant);
     });
 
     it('hass', () => {

--- a/tests/complex-templates.test.ts
+++ b/tests/complex-templates.test.ts
@@ -1,13 +1,12 @@
 import HomeAssistantJavaScriptTemplates from '../src';
-import { HomeAssistant } from '../src/types';
-import { HASS } from './constants';
+import { HOME_ASSISTANT_ELEMENT } from './constants';
 
 describe('Complex templates tests', () => {
 
     let compiler: HomeAssistantJavaScriptTemplates;
     
     beforeEach(() => {
-        compiler = new HomeAssistantJavaScriptTemplates({ hass: HASS } as HomeAssistant);
+        compiler = new HomeAssistantJavaScriptTemplates(HOME_ASSISTANT_ELEMENT);
     });
 
     it('templates', () => {

--- a/tests/complex-templates.test.ts
+++ b/tests/complex-templates.test.ts
@@ -1,4 +1,5 @@
 import HomeAssistantJavaScriptTemplates from '../src';
+import { HomeAssistant } from '../src/types';
 import { HASS } from './constants';
 
 describe('Complex templates tests', () => {
@@ -6,7 +7,7 @@ describe('Complex templates tests', () => {
     let compiler: HomeAssistantJavaScriptTemplates;
     
     beforeEach(() => {
-        compiler = new HomeAssistantJavaScriptTemplates(HASS);
+        compiler = new HomeAssistantJavaScriptTemplates({ hass: HASS } as HomeAssistant);
     });
 
     it('templates', () => {

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -1,4 +1,4 @@
-import { Hass } from '../src/types';
+import { Hass, HomeAssistant } from '../src/types';
 
 export const HASS: Hass = {
     areas: {
@@ -158,3 +158,7 @@ export const HASS: Hass = {
         name: 'ElChiniNet'
     }
 };
+
+export const HOME_ASSISTANT_ELEMENT = {
+    hass: HASS
+} as HomeAssistant;

--- a/tests/error-templates.test.ts
+++ b/tests/error-templates.test.ts
@@ -1,6 +1,5 @@
 import HomeAssistantJavaScriptTemplates from '../src';
-import { HomeAssistant } from '../src/types';
-import { HASS } from './constants';
+import { HOME_ASSISTANT_ELEMENT } from './constants';
 
 describe('Templates with errors', () => {
 
@@ -8,7 +7,7 @@ describe('Templates with errors', () => {
 
     it('Error as a console log', () => {
 
-        const compiler = new HomeAssistantJavaScriptTemplates({ hass: HASS } as HomeAssistant);
+        const compiler = new HomeAssistantJavaScriptTemplates(HOME_ASSISTANT_ELEMENT);
         const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
 
         expect(
@@ -23,7 +22,7 @@ describe('Templates with errors', () => {
 
     it('Error as an error', () => {
 
-        const compiler = new HomeAssistantJavaScriptTemplates({ hass: HASS } as HomeAssistant, true);
+        const compiler = new HomeAssistantJavaScriptTemplates(HOME_ASSISTANT_ELEMENT, true);
 
         expect(
             () => compiler.renderTemplate('states["binary_sensor.koffiezetapparaat_verbonden"].state.toFixed(16)')

--- a/tests/error-templates.test.ts
+++ b/tests/error-templates.test.ts
@@ -1,4 +1,5 @@
 import HomeAssistantJavaScriptTemplates from '../src';
+import { HomeAssistant } from '../src/types';
 import { HASS } from './constants';
 
 describe('Templates with errors', () => {
@@ -7,7 +8,7 @@ describe('Templates with errors', () => {
 
     it('Error as a console log', () => {
 
-        const compiler = new HomeAssistantJavaScriptTemplates(HASS);
+        const compiler = new HomeAssistantJavaScriptTemplates({ hass: HASS } as HomeAssistant);
         const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
 
         expect(
@@ -22,7 +23,7 @@ describe('Templates with errors', () => {
 
     it('Error as an error', () => {
 
-        const compiler = new HomeAssistantJavaScriptTemplates(HASS, true);
+        const compiler = new HomeAssistantJavaScriptTemplates({ hass: HASS } as HomeAssistant, true);
 
         expect(
             () => compiler.renderTemplate('states["binary_sensor.koffiezetapparaat_verbonden"].state.toFixed(16)')

--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -1,13 +1,12 @@
 import HomeAssistantJavaScriptTemplates from '../src';
-import { HomeAssistant } from '../src/types';
-import { HASS } from './constants';
+import { HOME_ASSISTANT_ELEMENT } from './constants';
 
 describe('Function tests', () => {
 
     let compiler: HomeAssistantJavaScriptTemplates;
     
     beforeEach(() => {
-        compiler = new HomeAssistantJavaScriptTemplates({ hass: HASS } as HomeAssistant);
+        compiler = new HomeAssistantJavaScriptTemplates(HOME_ASSISTANT_ELEMENT);
     });
 
     const methods = [

--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -1,4 +1,5 @@
 import HomeAssistantJavaScriptTemplates from '../src';
+import { HomeAssistant } from '../src/types';
 import { HASS } from './constants';
 
 describe('Function tests', () => {
@@ -6,7 +7,7 @@ describe('Function tests', () => {
     let compiler: HomeAssistantJavaScriptTemplates;
     
     beforeEach(() => {
-        compiler = new HomeAssistantJavaScriptTemplates(HASS);
+        compiler = new HomeAssistantJavaScriptTemplates({ hass: HASS } as HomeAssistant);
     });
 
     const methods = [


### PR DESCRIPTION
The main class doesn‘t accept a `hass` object anymore. It needs an HTML element that contains the `hass` object as a property. This is to solve a bug that the templates were returining always the old version of the states.

```javascript
import HomeAssistantJavaScriptTemplates  from 'home-assistant-javascript-templates';

const renderer = new HomeAssistantJavaScriptTemplates(
    document.querySelector('home-assistant')
);

renderer.renderTemplate('... template string ...');
```