### PR TITLE
Refactor states as an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.0] - 2024-01-29
+
+[BREAKING CHANGE]:
+    - `states` as an object will not return an array if a domain is used. In its place it will return an object with all the entities ids as keys.
+
 ## [2.0.0] - 2024-01-28
 
 [BREAKING CHANGE]:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The `hass` object
 
 #### states
 
-`states` could be used in two ways, as a function or as an object. When using it as function it only allows an entity id as a parameter and it will return the state of that entity. When using it as an object, you can use also an entity id but in those cases it will return the entire state object, so you need to access its `state` property to get the state value. When using it as an object with a domain, it will return an array with all the states of that domain.
+`states` could be used in two ways, as a function or as an object. When using it as function it only allows an entity id (containing the domain) as a parameter and it will return the state of that entity. As an object it allows you to access a domain or the full entity id.
 
 >Note: If you try to use `states` as a function sending a domain it will throw an error.
 
@@ -91,8 +91,11 @@ states('device_tracker.paulus') // returns the state of the entity id 'device_tr
 
 // Using states as an object
 states['device_tracker.paulus'].state // returns the state of the entity id 'device_tracker.paulus'
-states['device_tracker'] // returns an array with all the states of the 'device_tracker' domain
+states.device_tracker.paulus.state // returns the state of the entity id 'device_tracker.paulus'
+states.device_tracker // returns an object constaining all the entities of the 'device_tracker' domain
 ```
+
+>Note: Avoid using `states['device_tracker.paulus'].state` or `states.device_tracker.paulus.state`, instead use `states('device_tracker.paulus')` which will return `undefined` if the device id doesn‘t exist or the entity isn’t ready yet (the former will throw an error). If you still want to use them it is advisable to use the [Optional chaining operator], e.g. `states['device_tracker.paulus']?.state` or `states.device_tracker?.paulus?.state`.
 
 #### is_state
 
@@ -254,8 +257,11 @@ const renderer = new HomeAssistantJavaScriptTemplates(
 );
 
 renderer.renderTemplate(`
-    const udatesEntities = states['update'];
-    const updatesEntitiesOn = udatesEntities?.filter((entity) => entity.state === 'on');
-    return updatesEntitiesOn?.length || 0;
+    const udatesEntities = states.update;
+    const updateEntitiesValues = Object.values(udatesEntities);
+    const updatesEntitiesOn = updateEntitiesValues.filter((entity) => entity.state === 'on');
+    return updatesEntitiesOn.length;
 `);
 ```
+
+[Optional chaining operator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,6 @@
+export const NAMESPACE = '[home-assistant-javascript-templates]';
+export const DOMAIN_REGEXP = /^([a-z]+)\.(\w+)$/;
+
 export enum STATE_VALUES {
     UNKNOWN = 'unknown',
     UNAVAILABLE = 'unavailable'

--- a/tests/basic-templates.test.ts
+++ b/tests/basic-templates.test.ts
@@ -38,25 +38,29 @@ describe('Basic templates tests', () => {
         );
 
         expect(
+            compiler.renderTemplate('states.light.woonkamer_lamp')
+        ).toBeDefined();
+
+        expect(
+            compiler.renderTemplate('states.light.woonkamer_lamp')
+        ).toBe(
+            compiler.renderTemplate('states["light.woonkamer_lamp"]')
+        );
+
+        expect(
             compiler.renderTemplate('states("light.non_existent")')
         ).toBe(undefined);
 
         expect(
-            compiler.renderTemplate('states["sensor"]')
-        ).toHaveLength(2);
-
-        expect(
-            compiler.renderTemplate('states["sensor"]')
-        ).toMatchObject(
-            [
-                HASS.states['sensor.slaapkamer_temperatuur'],
-                HASS.states['sensor.slaapkamer_luchtvochtigheid']
-            ]
-        );
+            compiler.renderTemplate('states.sensor')
+        ).toMatchObject({
+            slaapkamer_temperatuur: HASS.states['sensor.slaapkamer_temperatuur'],
+            slaapkamer_luchtvochtigheid: HASS.states['sensor.slaapkamer_luchtvochtigheid']
+        });
 
         expect(
             compiler.renderTemplate('states["battery"]')
-        ).toMatchObject([]);
+        ).toMatchObject({});
 
     });
 

--- a/tests/complex-templates.test.ts
+++ b/tests/complex-templates.test.ts
@@ -14,16 +14,16 @@ describe('Complex templates tests', () => {
         expect(
             compiler.renderTemplate(`
                 const allStates = states["binary_sensor"];
-                const filter = allStates.filter((item) => {
-                    return item.state === 'off';
+                const filter = Object.entries(allStates).filter(([, stateObject]) => {
+                    return stateObject.state === 'off';
                 });
-                return "(" + filter[0].entity_id + ")";
+                return "(" + filter[0][1].entity_id + ")";
             `)
         ).toBe('(binary_sensor.internetverbinding)');
 
         expect(
             compiler.renderTemplate(`
-                const state = states("sensor.slaapkamer_luchtvochtigheid");
+                const state = states.sensor.slaapkamer_luchtvochtigheid;
                 if (+state > 50) {
                     return 'High';
                 }


### PR DESCRIPTION
This is a breaking change and will bump a major version of the library.

`states` as an object will not return an array if a domain is used. In its place it will return an object with all the entities ids as keys. This makes these two statements the same:

```javascript
states['device_tracker.paulus'] === states.device_tracker.paulus
```