### PR TITLE
Create a refactorings category in the releases notes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,12 +48,16 @@ jobs:
                   "labels": ["fix", "bug"]
                 },
                 {
-                  "title": "## 🧩 Dependencies",
-                  "labels": ["dependencies"]
+                  "title": "## 🔧 Refactorings",
+                  "labels": ["refactor"]
                 },
                 {
                   "title": "## ⚙️ Configuration",
                   "labels": ["configuration"]
+                },
+                {
+                  "title": "## 🧩 Dependencies",
+                  "labels": ["dependencies"]
                 },
                 {
                   "title": "## 🧪 Tests",


### PR DESCRIPTION
This pull request creates a `🔧 Refactorings` category in the release notes.