### PR TITLE
Fix entities as object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.0.1] - 2024-02-10
+
+- Fix a bug that was returning the wrong result with `states.any_entity_with_underscores`
+
 ## [3.0.0] - 2024-01-29
 
 [BREAKING CHANGE]:

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,5 @@
 export const NAMESPACE = '[home-assistant-javascript-templates]';
-export const DOMAIN_REGEXP = /^([a-z]+)\.(\w+)$/;
+export const DOMAIN_REGEXP = /^([a-z_]+)\.(\w+)$/;
 
 export enum STATE_VALUES {
     UNKNOWN = 'unknown',

--- a/tests/basic-templates.test.ts
+++ b/tests/basic-templates.test.ts
@@ -59,6 +59,14 @@ describe('Basic templates tests', () => {
         });
 
         expect(
+            compiler.renderTemplate('states.binary_sensor')
+        ).toMatchObject({
+            koffiezetapparaat_aan: HASS.states['binary_sensor.koffiezetapparaat_aan'],
+            koffiezetapparaat_verbonden: HASS.states['binary_sensor.koffiezetapparaat_verbonden'],
+            internetverbinding: HASS.states['binary_sensor.internetverbinding']
+        });
+
+        expect(
             compiler.renderTemplate('states["battery"]')
         ).toMatchObject({});
 


### PR DESCRIPTION
This pull request fixes a bug that was returning the wrong object when the `states` object was queried with an entity with underscores, e.g. `input_boolean`.