### PR TITLE
Create entities and domains tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.1.0] - 2024-02-11
+
+- Create entities and domains tracker
+
 ## [3.0.1] - 2024-02-10
 
 - Fix a bug that was returning the wrong result with `states.any_entity_with_underscores`

--- a/README.md
+++ b/README.md
@@ -69,9 +69,56 @@ new HomeAssistantJavaScriptTemplates(ha, throwErrors = false);
 | `ha`          | no            | An HTML element that has the `hass` object as a property (e.g. the `home-assistant` custom element). |
 | `throwErrors` | yes           | Indicates if the library should throw if the template contains any error. If not it will log the errors as a warning in the console and return `undefined` instead. |
 
-### renderTemplate method
+### Properties
 
-This is the main method to render `JavaScript` templates, it needs a string as a parameter. Inside this string you can use several objects and methods.
+#### tracked
+
+```typescript
+interface Tracked {
+    entities: string[];
+    domains: string[];
+}
+
+get tracked(): Tracked
+```
+
+This property will return an object with two properties (`entities` and `domains`). Each of these properties will be an array containing the entities or ids that have been tracked when the templates have been rendered. If some domain or entity was not reached because it was inside a condition that never met, then it will not be included in the `tracked` property. Only those entities or domains that were called during the rendering by the code using [states](#states), [is_state](#is_state), [state_attr](#state_attr), [is_state_attr](#is_state_attr) or [has_value](#has_value) will be included.
+
+>Note: take into account that the domains will be only tracked if the `states` object is used accesing a domain. For example `states('device_tracker.paulus')` or `states['device_tracker.paulus']` will track the entity `device_tracker.paulus` but not the domain `device_tracker` but `states.device_tracker.paulus` will track both, the domain `device_tracker` and the entity `device_tracker.paulus`. The rest of the methods will track only entities.
+
+### Methods
+
+#### renderTemplate
+
+```typescript
+renderTemplate(template: string): any
+```
+
+This is the main method to render `JavaScript` templates, it needs a string as a parameter. Inside this string you can use [several objects and methods](#objects-and-methods-available-in-the-templates). It returns whatever the `JavaScript` code returns, because of that it is typed as `any`.
+
+#### cleanTrackedEntities
+
+```typescript
+cleanTrackedEntities(): void
+```
+
+This method will clean all the tracked entities until the moment, so after being called, the `tracked` property will return an empty array as `entities`.
+
+#### cleanTrackedDomains
+
+```typescript
+cleanTrackedDomains(): void
+```
+
+This method will clean all the tracked domains until the moment, so after being called, the `tracked` property will return an empty array as `domains`.
+
+#### cleanTracked
+
+```typescript
+cleanTracked(): void
+```
+
+This method will clean all the tracked entities and domains until the moment. It is the same as calling `cleanTrackedEntities` and `cleanTrackedDomains` consecutively.
 
 ### Objects and methods available in the templates
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import {
     HomeAssistant,
     Hass,
-    Scopped
+    Scopped,
+    Tracked
 } from '@types';
 import { STRICT_MODE } from '@constants';
 import { createScoppedFunctions } from '@utilities';
@@ -16,7 +17,7 @@ export default class HomeAssistantJavaScriptTemplates {
     private _scopped: Scopped;
     private _errors: boolean;
 
-    public renderTemplate(template: string): string {
+    public renderTemplate(template: string): any {
 
         const functionBody = template.includes('return')
             ? template
@@ -75,6 +76,24 @@ export default class HomeAssistantJavaScriptTemplates {
         }
 
     }
+
+    public get tracked(): Tracked {
+        return this._scopped.tracked;
+    }
+
+    public cleanTrackedEntities(): void {
+        this._scopped.cleanTrackedEntities();
+    }
+
+    public cleanTrackedDomains(): void {
+        this._scopped.cleanTrackedDomains();
+    }
+
+    public cleanTracked(): void {
+        this._scopped.cleanTrackedEntities();
+        this._scopped.cleanTrackedDomains();
+    }
+
 }
 
 export { HomeAssistant, Hass };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,7 +40,12 @@ export interface HomeAssistant extends HTMLElement {
 
 export interface ProxiedStates {
     (entityId: string): string | undefined;
-    [entityId: string]: State[] | State | undefined;
+    [entityId: string]: Record<string, State> | State | undefined;
+}
+
+export interface Tracked {
+    entities: string[];
+    domains: string[];
 }
 
 export interface Scopped {
@@ -61,4 +66,7 @@ export interface Scopped {
     user_name: string;
     user_is_admin: boolean;
     user_is_owner: boolean;
+    tracked: Tracked;
+    cleanTrackedEntities: () => void;
+    cleanTrackedDomains: () => void;
 }

--- a/tests/basic-templates.test.ts
+++ b/tests/basic-templates.test.ts
@@ -15,7 +15,7 @@ describe('Basic templates tests', () => {
         ).toBe(
             HASS
         );
-    }),
+    });
 
     it('states', () => {
 
@@ -52,14 +52,14 @@ describe('Basic templates tests', () => {
         ).toBe(undefined);
 
         expect(
-            compiler.renderTemplate('states.sensor')
+            { ...compiler.renderTemplate('states.sensor') }
         ).toMatchObject({
             slaapkamer_temperatuur: HASS.states['sensor.slaapkamer_temperatuur'],
             slaapkamer_luchtvochtigheid: HASS.states['sensor.slaapkamer_luchtvochtigheid']
         });
 
         expect(
-            compiler.renderTemplate('states.binary_sensor')
+            { ...compiler.renderTemplate('states.binary_sensor') }
         ).toMatchObject({
             koffiezetapparaat_aan: HASS.states['binary_sensor.koffiezetapparaat_aan'],
             koffiezetapparaat_verbonden: HASS.states['binary_sensor.koffiezetapparaat_verbonden'],
@@ -67,7 +67,7 @@ describe('Basic templates tests', () => {
         });
 
         expect(
-            compiler.renderTemplate('states["battery"]')
+            { ...compiler.renderTemplate('states["battery"]') }
         ).toMatchObject({});
 
     });

--- a/tests/tracked.test.ts
+++ b/tests/tracked.test.ts
@@ -1,0 +1,407 @@
+import HomeAssistantJavaScriptTemplates from '../src';
+import { HOME_ASSISTANT_ELEMENT, HASS } from './constants';
+
+describe('cleanTracker false', () => {
+
+    let compiler: HomeAssistantJavaScriptTemplates;
+    
+    beforeEach(() => {
+        compiler = new HomeAssistantJavaScriptTemplates(HOME_ASSISTANT_ELEMENT);
+    });
+
+    it('test tracked entities using states as a function', () => {
+
+        compiler.renderTemplate(`
+            const state = states("binary_sensor.koffiezetapparaat_aan");
+            return state;
+        `);
+        compiler.renderTemplate(`
+            const stateLight = states("light.woonkamer_lamp");
+            const stateSensor = states("sensor.slaapkamer_temperatuur");
+            return stateLight === "on" || stateSensor === "on";
+        `);
+        compiler.renderTemplate(`
+            const state = states("binary_sensor.koffiezetapparaat_verbonden");
+            if (state === "off") {
+                return states("binary_sensor.internetverbinding");
+            }
+            return state;
+        `);
+        expect(compiler.tracked.entities).toHaveLength(4);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_aan',
+                'light.woonkamer_lamp',
+                'sensor.slaapkamer_temperatuur',
+                'binary_sensor.koffiezetapparaat_verbonden'
+            ])
+        );
+
+        compiler.renderTemplate(`
+            const state = states("binary_sensor.koffiezetapparaat_verbonden");
+            if (state === "on") {
+                return states("binary_sensor.internetverbinding");
+            }
+            return state;
+        `);
+        expect(compiler.tracked.entities).toHaveLength(5);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_aan',
+                'light.woonkamer_lamp',
+                'sensor.slaapkamer_temperatuur',
+                'binary_sensor.koffiezetapparaat_verbonden',
+                'binary_sensor.internetverbinding'
+            ])
+        );
+    });
+
+    it('test tracked entitites using states as an object', () => {
+        compiler.renderTemplate(`
+            const state = states["binary_sensor.koffiezetapparaat_aan"].states;
+            return state;
+        `);
+        compiler.renderTemplate(`
+            const stateLight = states["light.woonkamer_lamp"].state;
+            const stateSensor = states["sensor.slaapkamer_temperatuur"].state;
+            return stateLight === "on" || stateSensor === "on";
+        `);
+        compiler.renderTemplate(`
+            const state = states["binary_sensor.koffiezetapparaat_verbonden"].state;
+            if (state === "off") {
+                return states["binary_sensor.internetverbinding"].state;
+            }
+            return state;
+        `);
+        expect(compiler.tracked.entities).toHaveLength(4);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_aan',
+                'light.woonkamer_lamp',
+                'sensor.slaapkamer_temperatuur',
+                'binary_sensor.koffiezetapparaat_verbonden'
+            ])
+        );
+
+        compiler.renderTemplate(`
+            const state = states["binary_sensor.koffiezetapparaat_verbonden"].state;
+            if (state === "on") {
+                return states["binary_sensor.internetverbinding"].state;
+            }
+            return state;
+        `);
+        expect(compiler.tracked.entities).toHaveLength(5);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_aan',
+                'light.woonkamer_lamp',
+                'sensor.slaapkamer_temperatuur',
+                'binary_sensor.koffiezetapparaat_verbonden',
+                'binary_sensor.internetverbinding'
+            ])
+        );
+    });
+
+    it('test tracked entitites and domains using states as an object', () => {
+        compiler.renderTemplate(`
+            const state = states.binary_sensor.koffiezetapparaat_aan.states;
+            return state;
+        `);
+        compiler.renderTemplate(`
+            const stateLight = states.light.woonkamer_lamp.state;
+            const stateSensor = states.sensor.slaapkamer_temperatuur.state;
+            return stateLight === "on" || stateSensor === "on";
+        `);
+        compiler.renderTemplate(`
+            const state = states.binary_sensor.koffiezetapparaat_verbonden.state;
+            if (state === "off") {
+                return states.camera.keukencamera.state;
+            }
+            return state;
+        `);
+        expect(compiler.tracked.entities).toHaveLength(4);
+        expect(compiler.tracked.domains).toHaveLength(3);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_aan',
+                'light.woonkamer_lamp',
+                'sensor.slaapkamer_temperatuur',
+                'binary_sensor.koffiezetapparaat_verbonden'
+            ])
+        );
+        expect(compiler.tracked.domains).toEqual(
+            expect.arrayContaining([
+                'binary_sensor',
+                'light',
+                'sensor'
+            ])
+        );
+
+        compiler.renderTemplate(`
+            const state = states.binary_sensor.koffiezetapparaat_verbonden.state;
+            if (state === "on") {
+                return states.camera.keukencamera.state;
+            }
+            return state;
+        `);
+        expect(compiler.tracked.entities).toHaveLength(5);
+        expect(compiler.tracked.domains).toHaveLength(4);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_aan',
+                'light.woonkamer_lamp',
+                'sensor.slaapkamer_temperatuur',
+                'binary_sensor.koffiezetapparaat_verbonden',
+                'camera.keukencamera'
+            ])
+        );
+        expect(compiler.tracked.domains).toEqual(
+            expect.arrayContaining([
+                'binary_sensor',
+                'light',
+                'sensor',
+                'camera'
+            ])
+        );
+    });
+
+    it('get tracked entities and domains using states as a function as an object', () => {
+        compiler.renderTemplate('states("binary_sensor.koffiezetapparaat_verbonden")');
+        compiler.renderTemplate(`
+            const lampState = states.light.woonkamer_lamp;
+            return lampState;
+        `);
+        compiler.renderTemplate(`
+            const allButtons = states.button;
+            return Object.keys(allButtons);
+        `);
+        compiler.renderTemplate(`
+            const allSensors = states.sensor; return Object.keys(allSensors);
+        `);
+        compiler.renderTemplate(`
+            const mySensors = states["binary_sensor"];
+            return mySensors["internetverbinding"].state;
+        `);
+        expect(compiler.tracked.entities).toHaveLength(3);
+        expect(compiler.tracked.domains).toHaveLength(4);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_verbonden',
+                'light.woonkamer_lamp',
+                'binary_sensor.internetverbinding'
+            ])
+        );
+        expect(compiler.tracked.domains).toEqual(
+            expect.arrayContaining([
+                'light',
+                'button',
+                'sensor',
+                'binary_sensor'
+            ])
+        );
+
+        compiler.renderTemplate(`
+            return states.button.knopje.state;
+        `);
+        expect(compiler.tracked.entities).toHaveLength(4);
+        expect(compiler.tracked.domains).toHaveLength(4);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_verbonden',
+                'light.woonkamer_lamp',
+                'binary_sensor.internetverbinding',
+                'button.knopje'
+            ])
+        );
+        expect(compiler.tracked.domains).toEqual(
+            expect.arrayContaining([
+                'light',
+                'button',
+                'sensor',
+                'binary_sensor'
+            ])
+        );
+    });
+
+    it('get tracked entities using is_state', () => {
+        compiler.renderTemplate('return is_state("binary_sensor.internetverbinding", "on")');
+        compiler.renderTemplate(`
+            if (is_state("light.eetkamer_lampje", "off")) {
+                return states.light.eetkamer_lampje.attributes;
+            }
+            return is_state("sensor.slaapkamer_temperatuur", 10);
+        `);
+        compiler.renderTemplate('return is_state("binary_sensor.koffiezetapparaat_verbonden", "on")');
+        expect(compiler.tracked.entities).toHaveLength(4);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.internetverbinding',
+                'light.eetkamer_lampje',
+                'sensor.slaapkamer_temperatuur',
+                'binary_sensor.koffiezetapparaat_verbonden'
+            ])
+        );
+
+        compiler.renderTemplate('return is_state("light.woonkamer_lamp", "off")');
+        expect(compiler.tracked.entities).toHaveLength(5);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.internetverbinding',
+                'light.eetkamer_lampje',
+                'sensor.slaapkamer_temperatuur',
+                'binary_sensor.koffiezetapparaat_verbonden',
+                'light.woonkamer_lamp'
+            ])
+        );
+    });
+
+    it('get tracked entities using state_attr', () => {
+        compiler.renderTemplate('return state_attr("binary_sensor.koffiezetapparaat_verbonden", "friendly_name")');
+        compiler.renderTemplate(`
+            const attr = state_attr("sensor.slaapkamer_luchtvochtigheid", "state_class");
+            return attr;
+        `);
+        compiler.renderTemplate('return state_attr("binary_sensor.internetverbinding", "icon")');
+        expect(compiler.tracked.entities).toHaveLength(3);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_verbonden',
+                'sensor.slaapkamer_luchtvochtigheid',
+                'binary_sensor.internetverbinding'
+            ])
+        );
+
+        compiler.renderTemplate('return state_attr("light.eetkamer_lampje", "brightness")');
+        expect(compiler.tracked.entities).toHaveLength(4);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_verbonden',
+                'sensor.slaapkamer_luchtvochtigheid',
+                'binary_sensor.internetverbinding',
+                'light.eetkamer_lampje'
+            ])
+        );
+    });
+
+    it('get tracked entities using is_state_attr', () => {
+        compiler.renderTemplate('return is_state_attr("binary_sensor.koffiezetapparaat_verbonden", "friendly_name", "Koffiezetapparaat Verbonden")');
+        compiler.renderTemplate(`
+            const attr = is_state_attr("sensor.slaapkamer_luchtvochtigheid", "state_class", "battery");
+            return attr;
+        `);
+        compiler.renderTemplate('return is_state_attr("binary_sensor.internetverbinding", "icon", "mdi:person")');
+        expect(compiler.tracked.entities).toHaveLength(3);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_verbonden',
+                'sensor.slaapkamer_luchtvochtigheid',
+                'binary_sensor.internetverbinding'
+            ])
+        );
+
+        compiler.renderTemplate('return is_state_attr("light.eetkamer_lampje", "brightness", "100")');
+        expect(compiler.tracked.entities).toHaveLength(4);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'binary_sensor.koffiezetapparaat_verbonden',
+                'sensor.slaapkamer_luchtvochtigheid',
+                'binary_sensor.internetverbinding',
+                'light.eetkamer_lampje'
+            ])
+        );
+    });
+
+    it('get tracked entities using has_value', () => {
+        compiler.renderTemplate(`
+            const hasValue = has_value("button.knopje");
+            if (hasValue) {
+                return "yes";
+            }
+            return "false";
+        `);
+        compiler.renderTemplate(`
+            if (has_value("camera.keukencamera") && has_value("light.eetkamer_lampje")) {
+                return "available";
+            }
+            return false;
+        `);
+        compiler.renderTemplate('return has_value("binary_sensor.internetverbinding")');
+        expect(compiler.tracked.entities).toHaveLength(3);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'button.knopje',
+                'camera.keukencamera',
+                'binary_sensor.internetverbinding'
+            ])
+        );
+
+        compiler.renderTemplate('return has_value("light.eetkamer_lampje")');
+        expect(compiler.tracked.entities).toHaveLength(4);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        expect(compiler.tracked.entities).toEqual(
+            expect.arrayContaining([
+                'button.knopje',
+                'camera.keukencamera',
+                'binary_sensor.internetverbinding',
+                'light.eetkamer_lampje'
+            ])
+        );
+    });
+
+    it('non-existent devices or domains', () => {
+        compiler.renderTemplate('return states("binary_sensor.non_existent")');
+        compiler.renderTemplate('return states.climate.thermostat');
+        expect(compiler.tracked.entities).toHaveLength(0);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        
+        compiler.renderTemplate('return is_state("binary_sensor.my_sensor", "on")');
+        expect(compiler.tracked.entities).toHaveLength(0);
+        expect(compiler.tracked.domains).toHaveLength(0);
+
+        compiler.renderTemplate('return state_attr("camera.my_camera", "friendly_name")');
+        expect(compiler.tracked.entities).toHaveLength(0);
+        expect(compiler.tracked.domains).toHaveLength(0);
+
+        compiler.renderTemplate('return is_state_attr("sensor.my_sensor", "friendly_name", "My Sensor")');
+        expect(compiler.tracked.entities).toHaveLength(0);
+        expect(compiler.tracked.domains).toHaveLength(0);
+
+        compiler.renderTemplate('return has_value("domain.fake")');
+        expect(compiler.tracked.entities).toHaveLength(0);
+        expect(compiler.tracked.domains).toHaveLength(0);
+    });
+
+    it('cleaning trackers', () => {
+        compiler.renderTemplate('return states("binary_sensor.koffiezetapparaat_aan")');
+        compiler.renderTemplate('return states.sensor.slaapkamer_temperatuur.state');
+        expect(compiler.tracked.entities).toHaveLength(2);
+        expect(compiler.tracked.domains).toHaveLength(1);
+        compiler.cleanTrackedDomains();
+        expect(compiler.tracked.entities).toHaveLength(2);
+        expect(compiler.tracked.domains).toHaveLength(0);
+        compiler.cleanTrackedEntities();
+        expect(compiler.tracked.entities).toHaveLength(0);
+        expect(compiler.tracked.domains).toHaveLength(0);
+
+        compiler.renderTemplate('return states("binary_sensor.koffiezetapparaat_aan")');
+        compiler.renderTemplate('return states.sensor.slaapkamer_temperatuur.state');
+        expect(compiler.tracked.entities).toHaveLength(2);
+        expect(compiler.tracked.domains).toHaveLength(1);
+        compiler.cleanTracked();
+        expect(compiler.tracked.entities).toHaveLength(0);
+        expect(compiler.tracked.domains).toHaveLength(0);
+
+    });
+
+});


### PR DESCRIPTION
This pull request creates trackers for entitites and domains. If some entity or domain is used in the code and it is efectively called by `JavaScript` then they will be tracked and one can retreieve them from the class instance.

### Properties

#### tracked

```typescript
interface Tracked {
    entities: string[];
    domains: string[];
}

get tracked(): Tracked
```

This property will return an object with two properties (`entities` and `domains`). Each of these properties will be an array containing the entities or ids that have been tracked when the templates have been rendered. If some domain or entity was not reached because it was inside a condition that never met, then it will not be included in the `tracked` property. Only those entities or domains that were called during the rendering by the code using [states](#states), [is_state](#is_state), [state_attr](#state_attr), [is_state_attr](#is_state_attr) or [has_value](#has_value) will be included.

>Note: take into account that the domains will be only tracked if the `states` object is used accesing a domain. For example `states('device_tracker.paulus')` or `states['device_tracker.paulus']` will track the entity `device_tracker.paulus` but not the domain `device_tracker` but `states.device_tracker.paulus` will track both, the domain `device_tracker` and the entity `device_tracker.paulus`. The rest of the methods will track only entities.

### Methods

#### cleanTrackedEntities

```typescript
cleanTrackedEntities(): void
```

This method will clean all the tracked entities until the moment, so after being called, the `tracked` property will return an empty array as `entities`.

#### cleanTrackedDomains

```typescript
cleanTrackedDomains(): void
```

This method will clean all the tracked domains until the moment, so after being called, the `tracked` property will return an empty array as `domains`.

#### cleanTracked

```typescript
cleanTracked(): void
```

This method will clean all the tracked entities and domains until the moment. It is the same as calling `cleanTrackedEntities` and `cleanTrackedDomains` consecutively.

### Examples

```typescript
const koffiezetapparaatState = compiler.renderTemplate(`
    const state = states("binary_sensor.koffiezetapparaat_aan");
    return state;
`);

const sensorOrLightOn = compiler.renderTemplate(`
    const stateLight = states("light.woonkamer_lamp");
    const stateSensor = states.sensor.slaapkamer_temperatuur.state;
    return stateLight === "on" || stateSensor === "on";
`);

console.log(compiler.tracked);
```

The avove code will print this in the console:

```javascript
{
    entitites: [
        "binary_sensor.koffiezetapparaat_aan",
        "light.woonkamer_lamp",
        "sensor.slaapkamer_temperatuur"
    ],
    domains: ["sensor"]
}
```