### PR TITLE
Avoid throwing errors during the creation of the Function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,32 +19,32 @@ export default class HomeAssistantJavaScriptTemplates {
 
     public renderTemplate(template: string): any {
 
-        const functionBody = template.includes('return')
-            ? template
-            : `return ${template}`;
-
-        const templateFunction = new Function(
-            'hass',
-            'states',
-            'is_state',
-            'state_attr',
-            'is_state_attr',
-            'has_value',
-            'device_attr',
-            'is_device_attr',
-            'device_id',
-            'areas',
-            'area_id',
-            'area_name',
-            'area_entities',
-            'area_devices',
-            'user_name',
-            'user_is_admin',
-            'user_is_owner',
-            `${STRICT_MODE} ${functionBody}`
-        );
-
         try {
+
+            const functionBody = template.includes('return')
+                ? template
+                : `return ${template}`;
+
+            const templateFunction = new Function(
+                'hass',
+                'states',
+                'is_state',
+                'state_attr',
+                'is_state_attr',
+                'has_value',
+                'device_attr',
+                'is_device_attr',
+                'device_id',
+                'areas',
+                'area_id',
+                'area_name',
+                'area_entities',
+                'area_devices',
+                'user_name',
+                'user_is_admin',
+                'user_is_owner',
+                `${STRICT_MODE} ${functionBody}`
+            );
 
             return templateFunction(
                 this._scopped.hass,


### PR DESCRIPTION
When the class is instantiated with `throwErrors` in false, it should not throw errors, only warnings. But if the error does not occurred during compilation but during the instantiation of the `Function` then the code was throwing. This pull request fixes this avoiding throwing errors if the error is a Syntax error during instantiation.