### PR TITLE
Restore the registry-url to the set up node step

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
       - name: Publish
         run: |
           pnpm install


### PR DESCRIPTION
During the migration to `pnpm` the `registry-url` parameter of the Node set up step was removed. This pull request restores it.