### PR TITLE
Add a new property to get the Home Assistant panel url (`panel_url`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.2.0] - 2024-10-24
+
+- New property available in the templates `panel_url` which will return the `window.location.pathname`
+
 ## [5.1.0] - 2024-10-24
 
 - Fix an issue about calling `trackTemplate` with the same template but with different `renderingFunctions` was registering only the first one.

--- a/README.md
+++ b/README.md
@@ -338,6 +338,14 @@ Property to return the user agent of the browser in which Home Assistant is runn
 user_agent
 ```
 
+#### panel_url
+
+Property to return the current Home Assistant panel URL (`window.location.pathname`).
+
+```javascript
+panel_url
+```
+
 ## Examples
 
 #### Get a device attribute and return a formatted text with it
@@ -379,7 +387,7 @@ const haJsTemplates = new HomeAssistantJavaScriptTemplates(
 haJsTemplates.getRenderer()
     .then((renderer) => {
         const element = document.querySelector('#my-element');
-        renderer.trackTemplate(
+        const untrack = renderer.trackTemplate(
             `
             const udatesEntities = states.update;
             const updateEntitiesValues = Object.values(udatesEntities);
@@ -390,6 +398,10 @@ haJsTemplates.getRenderer()
                 element.innerHTML = result;
             }
         );
+
+        // Later untrack the template
+        untrack();
+
     });
 
 ```

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,0 +1,1 @@
+require('jest-location-mock');

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,4 +22,7 @@ module.exports = {
     testEnvironmentOptions: {
         userAgent: 'Custom/Agent',
     },
+    setupFilesAfterEnv: [
+        './jest-setup.js'
+    ]
 };

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/node": "^22.7.7",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-location-mock": "^2.0.0",
     "rollup": "^4.24.0",
     "rollup-plugin-ts": "^3.4.5",
     "ts-jest": "^29.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
+      jest-location-mock:
+        specifier: ^2.0.0
+        version: 2.0.0
       rollup:
         specifier: ^4.24.0
         version: 4.24.0
@@ -223,6 +226,9 @@ packages:
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
+
+  '@jedmao/location@3.0.0':
+    resolution: {integrity: sha512-p7mzNlgJbCioUYLUEKds3cQG4CHONVFJNYqMe6ocEtENCL/jYmMo1Q3ApwsMmU+L0ZkaDJEyv4HokaByLoPwlQ==}
 
   '@jest/console@29.7.0':
     resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
@@ -615,8 +621,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001580:
-    resolution: {integrity: sha512-mtj5ur2FFPZcCEpXFy8ADXbDACuNFXg6mxVDqp7tqooX6l3zwm+d8EPoeOSIFRDvHs8qu7/SLFOGniULkcH2iA==}
+  caniuse-lite@1.0.30001669:
+    resolution: {integrity: sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -1056,6 +1062,10 @@ packages:
   jest-leak-detector@29.7.0:
     resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-location-mock@2.0.0:
+    resolution: {integrity: sha512-loakfclgY/y65/2i4s0fcdlZY3hRPfwNnmzRsGFQYQryiaow2DEIGTLXIPI8cAO1Is36xsVLVkIzgvhQ+FXHdw==}
+    engines: {node: ^16.10.0 || >=18.0.0}
 
   jest-matcher-utils@29.7.0:
     resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
@@ -1889,6 +1899,8 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
+  '@jedmao/location@3.0.0': {}
+
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
@@ -2347,7 +2359,7 @@ snapshots:
       '@types/semver': 7.5.6
       '@types/ua-parser-js': 0.7.39
       browserslist: 4.22.3
-      caniuse-lite: 1.0.30001580
+      caniuse-lite: 1.0.30001669
       isbot: 3.8.0
       object-path: 0.11.8
       semver: 7.6.3
@@ -2355,7 +2367,7 @@ snapshots:
 
   browserslist@4.22.3:
     dependencies:
-      caniuse-lite: 1.0.30001580
+      caniuse-lite: 1.0.30001669
       electron-to-chromium: 1.4.648
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.3)
@@ -2376,7 +2388,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001580: {}
+  caniuse-lite@1.0.30001669: {}
 
   chalk@2.4.2:
     dependencies:
@@ -2869,6 +2881,11 @@ snapshots:
     dependencies:
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
+
+  jest-location-mock@2.0.0:
+    dependencies:
+      '@jedmao/location': 3.0.0
+      jest-diff: 29.7.0
 
   jest-matcher-utils@29.7.0:
     dependencies:

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,9 +11,18 @@ export enum ATTRIBUTES {
     NAME = 'name'
 }
 
+export enum CLIENT_SIDE_ENTITIES {
+    PANEL_URL = 'panel_url'
+}
+
+export enum EVENT {
+    LOCATION_CHANGED = 'location-changed',
+    POPSTATE = 'popstate',
+    SUBSCRIBE_EVENTS = 'subscribe_events',
+    STATE_CHANGE_EVENT = 'state_changed'
+}
+
 export const STRICT_MODE = '"use strict";';
 
 export const MAX_ATTEMPTS = 100;
 export const RETRY_DELAY = 50;
-export const SUBSCRIBE_EVENTS = 'subscribe_events';
-export const STATE_CHANGE_EVENT = 'state_changed';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,6 +117,8 @@ export interface Scopped {
     user_is_admin: boolean;
     user_is_owner: boolean;
     user_agent: string;
+    // others
+    panel_url: string;
     // utilities
     tracked: Set<string>;
     cleanTracked: () => void;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -14,7 +14,8 @@ import {
     STATE_VALUES,
     ATTRIBUTES,
     MAX_ATTEMPTS,
-    RETRY_DELAY
+    RETRY_DELAY,
+    CLIENT_SIDE_ENTITIES
 } from '@constants';
 
 const objectFromEntries = <T = unknown>(entries: [string, T][]): Record<string, T> => {
@@ -54,6 +55,10 @@ export function createScoppedFunctions(
         } else {
             warnNonExistentEntity(entityId);
         }
+    };
+
+    const trackClientSideEntity = (entity: CLIENT_SIDE_ENTITIES): void => {
+        entities.add(entity);
     };
 
     return {
@@ -268,6 +273,10 @@ export function createScoppedFunctions(
         },
         get user_agent() {
             return window.navigator.userAgent;
+        },
+        get panel_url() {
+            trackClientSideEntity(CLIENT_SIDE_ENTITIES.PANEL_URL);
+            return location.pathname;
         },
         get tracked() {
             return entities;

--- a/tests/basic-templates.test.ts
+++ b/tests/basic-templates.test.ts
@@ -577,4 +577,17 @@ describe('Basic templates tests', () => {
         });
     });
 
+    describe('panel_url', () => {
+
+        it('panel_url should return the default location.pathname', () => {
+            expect(compiler.renderTemplate('panel_url')).toBe('/');
+        });
+
+        it('', () => {
+            location.assign('/path/test');
+            expect(compiler.renderTemplate('panel_url')).toBe('/path/test'); 
+        });
+
+    });
+
 });

--- a/tests/promise-get-renderer.test.ts
+++ b/tests/promise-get-renderer.test.ts
@@ -1,6 +1,6 @@
 import HomeAssistantJavaScriptTemplates from '../src';
 import { HOME_ASSISTANT_ELEMENT, HASS } from './constants';
-import { SUBSCRIBE_EVENTS, STATE_CHANGE_EVENT } from '../src/constants';
+import { EVENT } from '../src/constants';
 
 describe('promise instance', () => {
 
@@ -32,8 +32,8 @@ describe('promise instance', () => {
         expect(subscribeMessage).toHaveBeenCalledWith(
             expect.any(Function),
             {
-                type: SUBSCRIBE_EVENTS,
-                event_type: STATE_CHANGE_EVENT
+                type: EVENT.SUBSCRIBE_EVENTS,
+                event_type: EVENT.STATE_CHANGE_EVENT
             }
         );
     });


### PR DESCRIPTION
This pull request implements a new property to retrieve the Home Assistant panel URL (`panel_url`). If this variable is used during a template tracking, the rendering function of the tracking will be executed every time the Home Assistant panel changes.