### PR TITLE
Update panel_url also when there is a change in a panel view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.2.1] - 2024-10-25
+
+- Fix `panel_url`, it should be updated also when the views change
+
 ## [5.2.0] - 2024-10-24
 
 - New property available in the templates `panel_url` which will return the `window.location.pathname`

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,9 +61,7 @@ class HomeAssistantJavaScriptTemplatesRenderer {
 
     private _watchForPanelUrlChange() {
         window.addEventListener(EVENT.LOCATION_CHANGED, (event: CustomEvent): void => {
-            if (event.detail.replace) {
-                this._panelUrlWatchCallback();
-            }
+            this._panelUrlWatchCallback();
         });
         window.addEventListener(EVENT.POPSTATE, () => {
             this._panelUrlWatchCallback();

--- a/tests/entities-change.test.ts
+++ b/tests/entities-change.test.ts
@@ -58,27 +58,9 @@ describe('promise instance', () => {
             renderingFunction
         );
         expect(renderingFunction).toHaveBeenNthCalledWith(1, "no");
-        window.dispatchEvent(
-            new CustomEvent(
-                EVENT.LOCATION_CHANGED,
-                {
-                    detail: {
-                        replace: false
-                    }
-                }
-            )
-        );
-        expect(renderingFunction).toHaveBeenCalledTimes(1);
         location.assign('/path/test');
         window.dispatchEvent(
-            new CustomEvent(
-                EVENT.LOCATION_CHANGED,
-                {
-                    detail: {
-                        replace: true
-                    }
-                }
-            )
+            new CustomEvent(EVENT.LOCATION_CHANGED)
         );
         expect(renderingFunction).toHaveBeenNthCalledWith(2, "yes");
     });


### PR DESCRIPTION
This pull request removes the check to update the `panel_url` variable only when the `CustomEvent` detail has a `replace` property in true, because when in the same lovelace dashboard one changes views, this variable is false, and the `panel_url` should be updated also in these cases.