### PR TITLE
Add an option to send custom variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.3.0] - 2024-10-25
+
+- New option to send custom variables to be rendered in the templates
+
 ## [5.2.1] - 2024-10-25
 
 - Fix `panel_url`, it should be updated also when the views change

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ new HomeAssistantJavaScriptTemplates(
 | ------------------ | ------------- | ------- | -------------------------------------------------- |
 | `throwErrors`      | yes           | false   | Indicates if the library should throw if the template contains any error. If not, it will log the errors as a warning in the console and return `undefined` instead. |
 | `throwWarnings`    | yes           | true    | Indicates if the library should throw warnings in the console, either when there is an error in the templates and `throwErrors` is configured in `false`, or when a non-existent entity or domain is used in the templates. |
+| `variables`        | yes           | `{}`    | An object holding custom variables to be used inside the templates. The values could be any type |
 
 ### Methods
 
@@ -381,7 +382,12 @@ haJsTemplates.getRenderer()
 import HomeAssistantJavaScriptTemplates  from 'home-assistant-javascript-templates';
 
 const haJsTemplates = new HomeAssistantJavaScriptTemplates(
-    document.querySelector('home-assistant')
+    document.querySelector('home-assistant'),
+    {
+        variables: {
+            PREFIX: 'Updates:'
+        }
+    }
 );
 
 haJsTemplates.getRenderer()
@@ -392,7 +398,7 @@ haJsTemplates.getRenderer()
             const udatesEntities = states.update;
             const updateEntitiesValues = Object.values(udatesEntities);
             const updatesEntitiesOn = updateEntitiesValues.filter((entity) => entity.state === 'on');
-            return updatesEntitiesOn.length;
+            return `${PREFIX} ${updatesEntitiesOn.length}`;
             `,
             (result) => {
                 element.innerHTML = result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,10 +22,14 @@ class HomeAssistantJavaScriptTemplatesRenderer {
     ) {
         const {
             throwErrors = false,
-            throwWarnings = true
+            throwWarnings = true,
+            variables = {}
         } = options;
         this._throwErrors = throwErrors;
         this._throwWarnings = throwWarnings;
+        this._variables = new Map(
+            Object.entries(variables)
+        );
         this._subscriptions = new Map<
             string,
             Map<
@@ -40,6 +44,7 @@ class HomeAssistantJavaScriptTemplatesRenderer {
 
     private _throwErrors: boolean;
     private _throwWarnings: boolean;
+    private _variables: Map<string, unknown>;
     private _subscriptions: Map<
         string,
         Map<
@@ -184,6 +189,7 @@ class HomeAssistantJavaScriptTemplatesRenderer {
                 'user_is_owner',
                 'panel_url',
                 'user_agent',
+                ...Array.from(this._variables.keys()),
                 `${STRICT_MODE} ${functionBody}`
             );
 
@@ -210,7 +216,8 @@ class HomeAssistantJavaScriptTemplatesRenderer {
                 this._scopped.user_is_admin,
                 this._scopped.user_is_owner,
                 this._scopped.panel_url,
-                this._scopped.user_agent
+                this._scopped.user_agent,
+                ...Array.from(this._variables.values()),
             );
 
         } catch (error) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export interface Options {
     throwErrors?: boolean;
     throwWarnings?: boolean;
+    variables?: Record<string, unknown>;
 }
 
 export type RenderingFunction = (result?: any) => void;

--- a/tests/custom-variables.test.ts
+++ b/tests/custom-variables.test.ts
@@ -1,0 +1,80 @@
+import HomeAssistantJavaScriptTemplates, { HomeAssistantJavaScriptTemplatesRenderer } from '../src';
+import { HOME_ASSISTANT_ELEMENT } from './constants';
+
+describe('Custom variables', () => {
+
+    let compiler: HomeAssistantJavaScriptTemplatesRenderer;
+
+    const variables = {
+        MY_STRING: 'CUSTOM_VALUE',
+        MY_NUMBER: 100,
+        MY_REGEXP: /^(\w+)-([A-Za-z]+)$/,
+        MY_OBJECT: {
+            prop: 'custom_prop'
+        },
+        MY_FUNCTION: (value: unknown) => typeof value === 'number'
+            ? value * 2
+            : `${value}_DOUBLE`,
+    };
+    
+    beforeEach(async () => {
+        window.hassConnection = Promise.resolve({
+            conn: {
+                subscribeMessage: jest.fn()
+            }
+        });
+        
+        compiler = await new HomeAssistantJavaScriptTemplates(HOME_ASSISTANT_ELEMENT, { variables }).getRenderer();
+    });
+
+    it('strig variable should be retrieved cocrrectly', () => {
+        expect(
+            compiler.renderTemplate('return MY_STRING + "_modified"')
+        ).toBe(
+            `${variables.MY_STRING}_modified`
+        );
+    });
+
+    it('number variable should be retrieved cocrrectly', () => {
+        expect(
+            compiler.renderTemplate('return MY_NUMBER / 2')
+        ).toBe(50);
+    });
+
+    it('regular expression variable should be retrieved cocrrectly', () => {
+        expect(
+            compiler.renderTemplate('MY_REGEXP.test("word_100")')
+        ).toBe(false);
+        expect(
+            compiler.renderTemplate('return MY_REGEXP.test("correct-word")')
+        ).toBe(true);
+        expect(
+            compiler.renderTemplate(`
+                const str = "100-words";
+                const replaced = str.replace(MY_REGEXP, "$2-$1");
+                return replaced;
+            `)
+        ).toBe('words-100');
+    });
+
+    it('object variable should be retrieved cocrrectly', () => {
+        expect(
+            compiler.renderTemplate(`
+                if ('prop' in MY_OBJECT) {
+                    return MY_OBJECT.prop;
+                }
+                return 'prop not found';
+            `)
+        ).toBe('custom_prop');
+    });
+
+    it('function variable should be retrieved cocrrectly', () => {
+        expect(
+            compiler.renderTemplate('MY_FUNCTION(5)')
+        ).toBe(10);
+        expect(
+            compiler.renderTemplate('MY_FUNCTION("STRING")')
+        ).toBe('STRING_DOUBLE');
+    });
+
+});


### PR DESCRIPTION
This pull request implements a new optional option to send to the class.

#### Configuration options

| Parameter          | Optional      | Default | Description                                        |
| ------------------ | ------------- | ------- | -------------------------------------------------- |
| `variables`        | yes           | `{}`    | An object holding custom variables to be used inside the templates. The values could be any type |

### Example

```typescript
import HomeAssistantJavaScriptTemplates  from 'home-assistant-javascript-templates';

const haJsTemplates = new HomeAssistantJavaScriptTemplates(
    document.querySelector('home-assistant'),
    {
        variables: {
            MY_NUMBER: 100,
            MY_STRING: 'custom-string'
        }
    }
);

haJsTemplates.getRenderer()
    .then((renderer) => {
        const result = renderer.renderTemplate(`
            return `${MY_NUMBER} ${MY_STRING}`;
        `);
        console.log(result); // 100 custom-string
    });
```