### PR TITLE
Fix templates with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.3.1] - 2024-10-25
+
+- Fix templates with spaces at the beginning
+
 ## [5.3.0] - 2024-10-25
 
 - New option to send custom variables to be rendered in the templates

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,9 +161,11 @@ class HomeAssistantJavaScriptTemplatesRenderer {
 
         try {
 
-            const functionBody = template.includes('return')
-                ? template
-                : `return ${template}`;
+            const trimmedTemplate = template.trim();
+
+            const functionBody = trimmedTemplate.includes('return')
+                ? trimmedTemplate
+                : `return ${trimmedTemplate}`;
 
             const templateFunction = new Function(
                 'hass',

--- a/tests/complex-templates.test.ts
+++ b/tests/complex-templates.test.ts
@@ -40,6 +40,13 @@ describe('Complex templates tests', () => {
             `)
         ).toBe('sn: 123456789');
 
+        expect(
+            compiler.renderTemplate(`
+
+                states("binary_sensor.koffiezetapparaat_aan")
+            `)
+        ).toBe('on');
+
     });
 
 });


### PR DESCRIPTION
If a template starts with a new line and without a return it was failing to render the template because the return was added before the empty line. This pull request fixes this making a trim of the template before adding the return.