### PR TITLE
Create a variables property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.4.0] - 2024-10-26
+
+- Create a variable property in the `HomeAssistantJavaScriptTemplatesRenderer` class
+
 ## [5.3.2] - 2024-10-26
 
 - Refactor variables retrieval

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Returns a `Promise` than once it resolved returns an instance of the [HomeAssist
 
 This class is only exported as a type in the package, you cannot import it directly. An instance of this class will be returned by the promise that is returned by the [getRenderer method](#getrenderer) of the [HomeAssistantJavaScriptTemplates class](#homeassistantjavascripttemplates-class).
 
+### Properties
+
+#### variables
+
+This property gets and sets the global variables that will be available in the templates.
+
 ### Methods
 
 #### renderTemplate

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,6 +252,14 @@ class HomeAssistantJavaScriptTemplatesRenderer {
         }   
     }
 
+    public get variables(): Record<string, unknown> {
+        return this._variables;
+    }
+
+    public set variables(value: Record<string, unknown>) {
+        this._variables = value;
+    }
+
 }
 
 export default class HomeAssistantJavaScriptTemplates {

--- a/tests/custom-variables.test.ts
+++ b/tests/custom-variables.test.ts
@@ -77,4 +77,18 @@ describe('Custom variables', () => {
         ).toBe('STRING_DOUBLE');
     });
 
+    it('retrieving the variables properties should return the same object sent in the HomeAssistantJavaScriptTemplates instance', () => {
+        expect(compiler.variables).toEqual(variables);
+    });
+
+    it('setting variables should override the global variables', () => {
+        const overrideVariables = {
+            ONLY_ONE: 'OVERRIDE'
+        };
+        compiler.variables = overrideVariables;
+        expect(compiler.variables).not.toMatchObject(variables);
+        expect(compiler.variables).toEqual(overrideVariables);
+        expect(compiler.renderTemplate('ONLY_ONE')).toBe('OVERRIDE');
+    });
+
 });


### PR DESCRIPTION
This pull request implements a `variables` property to set and get the global variables from the `HomeAssistantJavaScriptTemplatesRenderer` instances.