### PR TITLE
Remove getPromisableElement utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.4.1] - 2024-11-10
+
+- Remove `getPromisableElement` utility and replace it by the `getPromisableResult` from `get-promisable-result` package
+
 ## [5.4.0] - 2024-10-26
 
 - Create a variable property in the `HomeAssistantJavaScriptTemplatesRenderer` class

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.8.7",
+    "get-promisable-result": "^1.0.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-location-mock": "^2.0.0",
@@ -56,5 +57,8 @@
     "ts-jest": "^29.2.5",
     "tslib": "^2.8.1",
     "typescript": "^5.6.3"
+  },
+  "peerDependencies": {
+    "get-promisable-result": "^1.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@types/node':
         specifier: ^22.8.7
         version: 22.8.7
+      get-promisable-result:
+        specifier: ^1.0.1
+        version: 1.0.1
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.8.7)
@@ -852,6 +855,9 @@ packages:
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-promisable-result@1.0.1:
+    resolution: {integrity: sha512-hUUKs/s8qoeH4gk3NPcKjCWaCjOv0S+kyT3oTuJXneEWYzwmyfEJHESU2ES7pMZNVHTjMt7X8hpmThFfggTVtg==}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -2562,6 +2568,8 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-package-type@0.1.0: {}
+
+  get-promisable-result@1.0.1: {}
 
   get-stream@6.0.1: {}
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,7 @@ export default [
                 }
             })
         ],
+        external: ['get-promisable-result'],
         input: 'src/index.ts',
         output: [
             {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -23,6 +23,3 @@ export enum EVENT {
 }
 
 export const STRICT_MODE = '"use strict";';
-
-export const MAX_ATTEMPTS = 100;
-export const RETRY_DELAY = 50;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { getPromisableResult } from 'get-promisable-result';
 import {
     HomeAssistant,
     Hass,
@@ -12,7 +13,7 @@ import {
     CLIENT_SIDE_ENTITIES,
     EVENT
 } from '@constants';
-import { createScoppedFunctions, getPromisableElement } from '@utilities';
+import { createScoppedFunctions } from '@utilities';
 
 class HomeAssistantJavaScriptTemplatesRenderer {
 
@@ -267,7 +268,7 @@ export default class HomeAssistantJavaScriptTemplates {
         ha: HomeAssistant,
         options: Options = {}
     ) {
-        this._renderer = getPromisableElement(
+        this._renderer = getPromisableResult(
             () => ha.hass,
             (hass: Hass): boolean => !!(
                 hass &&
@@ -276,12 +277,14 @@ export default class HomeAssistantJavaScriptTemplates {
                 hass.entities &&
                 hass.states &&
                 hass.user
-            )
+            ),
+            {
+                retries: 100,
+                delay: 50,
+                rejectMessage: 'The provided element doesn\'t contain a proper or initialised hass object'
+            }
         )
             .then(() => new HomeAssistantJavaScriptTemplatesRenderer(ha, options))
-            .catch(() => {
-                throw new Error('The provided element doesn\'t contain a proper or initialised hass object');
-            });;
     }
 
     private _renderer: Promise<HomeAssistantJavaScriptTemplatesRenderer>;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -13,8 +13,6 @@ import {
     ENTITY_REGEXP,
     STATE_VALUES,
     ATTRIBUTES,
-    MAX_ATTEMPTS,
-    RETRY_DELAY,
     CLIENT_SIDE_ENTITIES
 } from '@constants';
 
@@ -286,26 +284,3 @@ export function createScoppedFunctions(
         }
     };
 }
-
-export const getPromisableElement = <T>(
-    getElement: () => T,
-    check: (element: T) => boolean
-): Promise<T> => {
-    return new Promise<T>((resolve, reject) => {
-        let attempts = 0;
-        const select = () => {
-            const element: T = getElement();
-            if (check(element)) {
-                resolve(element);
-            } else {
-                attempts++;
-                if (attempts < MAX_ATTEMPTS) {
-                    setTimeout(select, RETRY_DELAY);
-                } else {
-                    reject();
-                }
-            }
-        };
-        select();
-    });
-};


### PR DESCRIPTION
This pull request removes the `getPromisableElement` utility and starts to use the `getPromisableResult` utility from [get-promisable-result](https://github.com/elchininet/get-promisable-result) package.