### PR TITLE
Set the get-promisable-result package as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.4.2] - 2024-11-10
+
+- Set the `get-promisable-result` package as a dependency
+
 ## [5.4.1] - 2024-11-10
 
 - Remove `getPromisableElement` utility and replace it by the `getPromisableResult` from `get-promisable-result` package

--- a/README.md
+++ b/README.md
@@ -9,24 +9,22 @@ A JavaScript utility to render Home Assistant JavaScript templates.
 
 ## Install
 
-The package needs the [get-promisable-result](https://github.com/elchininet/get-promisable-result) package as a peer dependency.
-
 #### npm
 
 ```bash
-npm install get-promisable-result home-assistant-javascript-templates
+npm install home-assistant-javascript-templates
 ```
 
 #### yarn
 
 ```bash
-yarn add get-promisable-result home-assistant-javascript-templates
+yarn add home-assistant-javascript-templates
 ```
 
 #### PNPM
 
 ```bash
-pnpm add get-promisable-result home-assistant-javascript-templates
+pnpm add home-assistant-javascript-templates
 ```
 
 ## Basic Usage

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "tslib": "^2.8.1",
     "typescript": "^5.6.3"
   },
-  "peerDependencies": {
+  "dependencies": {
     "get-promisable-result": "^1.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      get-promisable-result:
+        specifier: ^1.0.0
+        version: 1.0.1
     devDependencies:
       '@rollup/plugin-terser':
         specifier: ^0.4.4
@@ -17,9 +21,6 @@ importers:
       '@types/node':
         specifier: ^22.8.7
         version: 22.8.7
-      get-promisable-result:
-        specifier: ^1.0.1
-        version: 1.0.1
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.8.7)


### PR DESCRIPTION
This pull request sets the `get-promisable-result` as a dependency.