### PR TITLE
Add a new option to avoid adding an auto return at the beginning of a template code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.5.0] - 2024-11-10
+
+- Add a new option `autoReturn` to manage the feature of adding `return statements at the beginning of the templates`
+
 ## [5.4.2] - 2024-11-10
 
 - Set the `get-promisable-result` package as a dependency

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ new HomeAssistantJavaScriptTemplates(
 | `throwErrors`      | yes           | false   | Indicates if the library should throw if the template contains any error. If not, it will log the errors as a warning in the console and return `undefined` instead. |
 | `throwWarnings`    | yes           | true    | Indicates if the library should throw warnings in the console, either when there is an error in the templates and `throwErrors` is configured in `false`, or when a non-existent entity or domain is used in the templates. |
 | `variables`        | yes           | `{}`    | An object holding custom variables to be used inside the templates. The values could be any type |
+| `autoReturn`       | yes           | true    | Indicates if the library should add a `return` statement at the beginning of a template code if no `return` statements are contained in the code|
 
 ### Methods
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,11 +24,13 @@ class HomeAssistantJavaScriptTemplatesRenderer {
         const {
             throwErrors = false,
             throwWarnings = true,
-            variables = {}
+            variables = {},
+            autoReturn = true
         } = options;
         this._throwErrors = throwErrors;
         this._throwWarnings = throwWarnings;
         this._variables = variables;
+        this._autoReturn = autoReturn;
         this._subscriptions = new Map<
             string,
             Map<
@@ -44,6 +46,7 @@ class HomeAssistantJavaScriptTemplatesRenderer {
     private _throwErrors: boolean;
     private _throwWarnings: boolean;
     private _variables: Record<string, unknown>;
+    private _autoReturn: boolean;
     private _subscriptions: Map<
         string,
         Map<
@@ -165,7 +168,7 @@ class HomeAssistantJavaScriptTemplatesRenderer {
             );
             const trimmedTemplate = template.trim();
 
-            const functionBody = trimmedTemplate.includes('return')
+            const functionBody = trimmedTemplate.includes('return') || !this._autoReturn
                 ? trimmedTemplate
                 : `return ${trimmedTemplate}`;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export interface Options {
     throwErrors?: boolean;
     throwWarnings?: boolean;
     variables?: Record<string, unknown>;
+    autoReturn?: boolean;
 }
 
 export type RenderingFunction = (result?: any) => void;

--- a/tests/auto-return.test.ts
+++ b/tests/auto-return.test.ts
@@ -1,0 +1,23 @@
+import HomeAssistantJavaScriptTemplates, { HomeAssistantJavaScriptTemplatesRenderer } from '../src';
+import { HOME_ASSISTANT_ELEMENT } from './constants';
+
+describe('autoReturn', () => {
+
+    let compiler: HomeAssistantJavaScriptTemplatesRenderer;
+    
+    beforeEach(async () => {   
+        window.hassConnection = Promise.resolve({
+            conn: {
+                subscribeMessage: jest.fn()
+            }
+        });     
+        compiler = await new HomeAssistantJavaScriptTemplates(HOME_ASSISTANT_ELEMENT, { autoReturn: false }).getRenderer();
+    });
+
+    it('if there is no return the template should return undefined', () => {
+        expect(
+            compiler.renderTemplate('states["light.woonkamer_lamp"].state')
+        ).toBe(undefined);
+    });
+
+});


### PR DESCRIPTION
This pull request adds a new option to the class configuration.

#### Configuration options

| Parameter          | Optional      | Default | Description                                        |
| ------------------ | ------------- | ------- | -------------------------------------------------- |
| `autoReturn`       | yes           | true    | Indicates if the library should add a `return` statement at the beginning of a template code if no `return` statements are contained in the code |

**autoReturn in true (default)**

```javascript
const haJsTemplates = new HomeAssistantJavaScriptTemplates(
    document.querySelector('home-assistant')
);

haJsTemplates.getRenderer()
    then((renderer) => {
        renderer.renderTemplate('true') === true; // true
    });
```

**autoReturn in false**

```javascript
const haJsTemplates = new HomeAssistantJavaScriptTemplates(
    document.querySelector('home-assistant'),
    {
        autoReturn: false
    }
);

haJsTemplates.getRenderer()
    then((renderer) => {
        renderer.renderTemplate('true') === undefined; // true
        renderer.renderTemplate('return true') === true; // true
    });
```