### PR TITLE
Fix a bug with panel_url registering entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.5.1] - 2024-12-14
+
+- Fix a bug about panel_url registering all the entity_ids of all registered templates
+
 ## [5.5.0] - 2024-11-10
 
 - Add a new option `autoReturn` to manage the feature of adding `return` statements at the beginning of the templates

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -120,7 +120,7 @@ export interface Scopped {
     user_is_owner: boolean;
     user_agent: string;
     // others
-    panel_url: string;
+    clientSideProxy: Record<string, unknown>;
     // utilities
     tracked: Set<string>;
     cleanTracked: () => void;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -272,15 +272,25 @@ export function createScoppedFunctions(
         get user_agent() {
             return window.navigator.userAgent;
         },
-        get panel_url() {
-            trackClientSideEntity(CLIENT_SIDE_ENTITIES.PANEL_URL);
-            return location.pathname;
-        },
         get tracked() {
             return entities;
         },
         cleanTracked(): void {
             entities.clear();
-        }
+        },
+        clientSideProxy: new Proxy(
+            {},
+            {
+                get(__target, property: string) {
+                    if (property === CLIENT_SIDE_ENTITIES.PANEL_URL) {
+                        trackClientSideEntity(CLIENT_SIDE_ENTITIES.PANEL_URL);
+                        return location.pathname;
+                    }
+                    if(throwWarnings) {
+                        console.warn(`clientSideProxy should only be used to access these variables: ${Object.values(CLIENT_SIDE_ENTITIES).join(', ')}`);
+                    }
+                }
+            }
+        )
     };
 }

--- a/tests/error-templates.test.ts
+++ b/tests/error-templates.test.ts
@@ -155,4 +155,23 @@ describe('Templates with errors', () => {
 
     });
 
+    describe('trying to access other clientSide variables', () => {
+
+        let consoleWarnMock: jest.SpyInstance<void, [message?: any, ...optionalParams: any[]]>;
+        let compiler: HomeAssistantJavaScriptTemplatesRenderer;
+
+        beforeEach(async () => {
+            consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
+            compiler = await new HomeAssistantJavaScriptTemplates(HOME_ASSISTANT_ELEMENT).getRenderer();
+        });
+
+        it('accesing a variable inside clientSide', () => {
+            expect(
+                compiler.renderTemplate('return clientSide.non_existent')
+            ).toBe(undefined);
+            expect(consoleWarnMock).toHaveBeenCalledWith('clientSideProxy should only be used to access these variables: panel_url');
+        });
+
+    });
+
 });


### PR DESCRIPTION
This pull request fixes a bug about `panel_url` that was taking control of all entity changes, so all the registered function were called if `panel_url` changed.