### PR TITLE
Implement reactive variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.6.0] - 2025-01-16
+
+- Add two new functions to the templates to work with reactive variables (`ref` and `unref`)
+
 ## [5.5.1] - 2024-12-14
 
 - Fix a bug about panel_url registering all the entity_ids of all registered templates

--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ The `hass` object
 
 `states` could be used in two ways, as a function or as an object. When using it as function it only allows an entity id (containing the domain) as a parameter and it will return the state of that entity. As an object it allows you to access a domain or the full entity state object.
 
->Note: If you try to use `states` as a function sending a domain it will throw an error.
+>[!IMPORTANT]
+>If you try to use `states` as a function sending a domain it will throw an error.
 
 ```javascript
 // Using states as a function
@@ -165,7 +166,8 @@ states.device_tracker.paulus.state // returns the state of the entity id 'device
 states.device_tracker // returns an object containing all the entities states of the 'device_tracker' domain
 ```
 
->Note: Avoid using `states['device_tracker.paulus'].state` or `states.device_tracker.paulus.state`, instead use `states('device_tracker.paulus')` which will return `undefined` if the device id doesn‘t exist or the entity isn’t ready yet (the former will throw an error). If you still want to use them it is advisable to use the [Optional chaining operator], e.g. `states['device_tracker.paulus']?.state` or `states.device_tracker?.paulus?.state`.
+>[!TIP]
+>Avoid using `states['device_tracker.paulus'].state` or `states.device_tracker.paulus.state`, instead use `states('device_tracker.paulus')` which will return `undefined` if the device id doesn‘t exist or the entity isn’t ready yet (the former will throw an error). If you still want to use them it is advisable to use the [Optional chaining operator], e.g. `states['device_tracker.paulus']?.state` or `states.device_tracker?.paulus?.state`.
 
 #### is_state
 
@@ -353,6 +355,30 @@ Property to return the current Home Assistant panel URL (`window.location.pathna
 ```javascript
 panel_url
 ```
+
+#### ref and unref
+
+`ref` and `unref` method allows to work with reactive variables. Reactive variables are variables that can be accessed globally from any template and changing their values in any template will trigger a re-render in the tracked templates using them.
+
+```javascript
+// create a ref to a variable named name
+const name = ref('name');
+
+// Changing the value of the ref name
+// This will re-evaluate any template in which ref('name') has been used
+name.value = 'ElChiniNet';
+
+// Accesing the value of the ref name
+const myName = name.value;
+
+// Remove the ref name
+// This will stop any re-evaluation of this reactive variable in any template
+unref('name');
+```
+
+>[!IMPORTANT]
+>1. A `ref` has only one property, and it is `value`. Trying to access or assign another property than value will throw an error.
+>2. `unref` should be called if a `ref` has been created previously or if it has not been already _unrefed_. Trying to call `unref` in a non-existent `ref` will throw an error.
 
 ## Examples
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,11 @@ class HomeAssistantJavaScriptTemplatesRenderer {
             'gm'
         );
 
-        this._scopped = createScoppedFunctions(ha, throwWarnings);
+        this._scopped = createScoppedFunctions(
+            ha,
+            throwErrors,
+            throwWarnings
+        );
         this._watchForPanelUrlChange();
         this._watchForEntitiesChange();
     }
@@ -207,6 +211,8 @@ class HomeAssistantJavaScriptTemplatesRenderer {
                 'user_is_owner',
                 'user_agent',
                 'clientSide',
+                'ref',
+                'unref',
                 ...Array.from(variables.keys()),
                 `${STRICT_MODE} ${functionBody}`
             );
@@ -235,6 +241,14 @@ class HomeAssistantJavaScriptTemplatesRenderer {
                 this._scopped.user_is_owner,
                 this._scopped.user_agent,
                 this._scopped.clientSideProxy,
+                this._scopped.ref.bind(
+                    this._scopped,
+                    this._entityWatchCallback.bind(this)
+                ),
+                this._scopped.unref.bind(
+                    this._scopped,
+                    this.cleanTracked.bind(this)
+                ),
                 ...Array.from(variables.values()),
             );
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -91,6 +91,10 @@ declare global {
     }
 }
 
+export type Ref = {
+    value: unknown;
+};
+
 export interface Scopped {
     hass: Hass;
     // states
@@ -123,5 +127,7 @@ export interface Scopped {
     clientSideProxy: Record<string, unknown>;
     // utilities
     tracked: Set<string>;
+    ref(entityWatchCallback: (event: SubscriberEvent) => void, name: string, value?: unknown): Ref;
+    unref(cleanTracked: (refId: string) => void, name: string): void;
     cleanTracked: () => void;
 }

--- a/tests/refs.test.ts
+++ b/tests/refs.test.ts
@@ -1,0 +1,328 @@
+import HomeAssistantJavaScriptTemplates, { HomeAssistantJavaScriptTemplatesRenderer } from '../src';
+import { HOME_ASSISTANT_ELEMENT, HASS } from './constants';
+
+describe('ref and unref without errors', () => {
+
+    let compiler: HomeAssistantJavaScriptTemplatesRenderer;
+    let consoleWarnMock: jest.SpyInstance<void, [message?: any, ...optionalParams: any[]]>;
+    
+    beforeEach(async () => {
+        window.hassConnection = Promise.resolve({
+            conn: {
+                subscribeMessage: jest.fn()
+            }
+        });
+        consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
+        compiler = await new HomeAssistantJavaScriptTemplates(HOME_ASSISTANT_ELEMENT).getRenderer();
+    });
+
+    afterEach(() => {
+        consoleWarnMock.mockRestore();
+    });
+
+    describe('renderTemplate with refs', () => {
+
+        it('ref value should be undefined by default', () => {
+            expect(
+                compiler.renderTemplate(`
+                    const myRef = ref('custom');
+                    return myRef.value;
+                `)
+            ).toBe(undefined);
+        });
+
+        it('if a value is assigned to a refit should return that value', () => {
+            expect(
+                compiler.renderTemplate(`
+                    const myRef = ref('custom');
+                    myRef.value = 'Assigned';
+                    return myRef.value;
+                `)
+            ).toBe('Assigned');
+        });
+
+        it('two refs with the same name should make reference to the same object', () => {
+            expect(
+                compiler.renderTemplate(`
+                    const one = ref('custom');
+                    const two = ref('custom');
+                    return one === two;
+                `)
+            ).toBe(true);
+        });
+
+        it('a ref created in a template should be accesed from another template', () => {
+            compiler.renderTemplate(`
+                const myRef = ref('custom');
+                myRef.value = 'changed';
+                return true;
+            `);
+            expect(
+                compiler.renderTemplate(`
+                    const myRef = ref('custom');
+                    return myRef.value;
+                `)
+            ).toBe('changed');
+        });
+
+        it('a ref should support objects', () => {
+            compiler.renderTemplate(`
+                const myRef = ref('custom');
+                myRef.value = { prop: 'refProp' };
+                return true;
+            `);
+            expect(
+                compiler.renderTemplate(`
+                    const myRef = ref('custom');
+                    myRef.value.prop = 'changed';
+                    return myRef.value;
+                `)
+            ).toEqual({ prop: 'changed' });
+        });
+
+        it('a ref should support arrays', () => {
+            compiler.renderTemplate(`
+                const myRef = ref('custom');
+                myRef.value = [1, 2, 3];
+                return true;
+            `);
+            expect(
+                compiler.renderTemplate(`
+                    const myRef = ref('custom');
+                    myRef.value.push(4);
+                    return myRef.value;
+                `)
+            ).toEqual([1, 2, 3, 4]);
+        });
+
+        it('refs should not allow to access other properties but value', () => {
+            compiler.renderTemplate(`
+                const myRef = ref('custom');
+                return myRef.customProp;
+            `);
+            expect(consoleWarnMock).toHaveBeenCalledWith(new SyntaxError('customProp is not a valid ref property. A ref only exposes a value property'));
+        });
+
+        it('refs should not allow to assign other properties but value', () => {
+            compiler.renderTemplate(`
+                const myRef = ref('custom');
+                myRef.customProp = 'changed';
+                return true;
+            `);
+            expect(consoleWarnMock).toHaveBeenCalledWith(new SyntaxError('property customProp cannot be set in a ref'));
+        });
+
+    });
+
+    describe('renderTemplate with unrefs', () => {
+
+        it('unref should remove the ref', () => {
+            expect(
+                compiler.renderTemplate(`
+                    const myRef = ref('custom');
+                    myRef.value = 'changed';
+                    unref('custom');
+                    return ref('custom').value;
+                `)
+            ).toBe(undefined);
+        });
+
+        it('unref in one template should remove the ref also in other templates', () => {
+            compiler.renderTemplate(`
+                const myRef = ref('custom');
+                myRef.value = 'changed';
+                unref('custom');
+                return true;
+            `);
+            expect(
+                compiler.renderTemplate(`
+                    const myRef = ref('custom');
+                    return myRef.value;
+                `)
+            ).toBe(undefined);
+        });
+
+        it('after unref, two refs with the same name do not reference the same object', () => {
+            expect(
+                compiler.renderTemplate(`
+                    const one = ref('custom');
+                    unref('custom');
+                    const two = ref('custom');
+                    return one === two;
+                `)
+            ).toBe(false);
+        });
+
+        it('trying to unref a non defined ref should not be allowed', () => {
+            compiler.renderTemplate(`
+                unref('custom');
+                return true;
+            `);
+            expect(consoleWarnMock).toHaveBeenCalledWith(new SyntaxError('custom is not a ref or it has been unrefed already'));
+        });
+
+    });
+
+    describe('trackTemplate with refs', () => {
+
+        it('changing the value of a ref in a template should rerender all templates using it', () => {
+
+            const renderingFunction1 = jest.fn();
+            const renderingFunction2 = jest.fn();
+            const renderingFunction3 = jest.fn();
+
+            compiler.trackTemplate(
+                `
+                    const one = ref('one');
+                    if (one.value) {
+                        return 'yes';
+                    }
+                    return 'no';
+                `,
+                renderingFunction1
+            );
+
+            compiler.trackTemplate(
+                `
+                    const two = ref('two');
+                    return two.value;
+                `,
+                renderingFunction2
+            );
+
+            expect(renderingFunction1).toHaveBeenNthCalledWith(1, 'no');
+            expect(renderingFunction2).toHaveBeenNthCalledWith(1, undefined);
+            expect(renderingFunction3).not.toHaveBeenCalled();
+
+            compiler.trackTemplate(
+                `
+                    const one = ref('one');
+                    const two = ref('two');
+                    one.value = 'one';
+                    two.value = 'two';
+                    return one.value + '/' + two.value;
+                `,
+                renderingFunction3
+            );
+
+            expect(renderingFunction1).toHaveBeenNthCalledWith(2, 'yes');
+            expect(renderingFunction2).toHaveBeenNthCalledWith(2, 'two');
+            expect(renderingFunction3).toHaveBeenNthCalledWith(1, 'one/two');
+
+        });
+
+    });
+
+    describe('trackTemplate with unrefs', () => {
+
+        it('after unref a ref, templates that were using it should not trigger anymore', () => {
+
+            const renderingFunction1 = jest.fn();
+            const renderingFunction2 = jest.fn();
+            const renderingFunction3 = jest.fn();
+
+            compiler.trackTemplate(
+                `
+                    const myRef = ref('custom');
+                    if (myRef.value) {
+                        return 'yes';
+                    }
+                    return 'no';
+                `,
+                renderingFunction1
+            );
+
+            expect(renderingFunction1).toHaveBeenNthCalledWith(1, 'no');
+            expect(renderingFunction2).not.toHaveBeenCalled();
+            expect(renderingFunction3).not.toHaveBeenCalled();
+
+            compiler.trackTemplate(
+                `
+                    const myRef = ref('custom');
+                    myRef.value = 'changed';
+                    return myRef.value;
+                `,
+                renderingFunction2
+            );
+
+            expect(renderingFunction1).toHaveBeenNthCalledWith(2, 'yes');
+            expect(renderingFunction2).toHaveBeenNthCalledWith(1, 'changed');
+            expect(renderingFunction3).not.toHaveBeenCalled();
+
+            compiler.trackTemplate(
+                `
+                    unref('custom');
+                    const myRef = ref('custom');
+                    myRef.value = 're-changed';
+                    return myRef.value;
+                `,
+                renderingFunction3
+            );
+
+            expect(renderingFunction1).not.toHaveBeenCalledTimes(3);
+            expect(renderingFunction2).not.toHaveBeenCalledTimes(2);
+            expect(renderingFunction3).toHaveBeenNthCalledWith(1, 're-changed');
+
+        });
+
+    });
+
+});
+
+describe('ref and unref with errors', () => {
+
+    let compiler: HomeAssistantJavaScriptTemplatesRenderer;
+    
+    beforeEach(async () => {
+        window.hassConnection = Promise.resolve({
+            conn: {
+                subscribeMessage: jest.fn()
+            }
+        });
+        compiler = await new HomeAssistantJavaScriptTemplates(
+            HOME_ASSISTANT_ELEMENT,
+            {
+                throwErrors: true
+            }
+        ).getRenderer();
+    });
+
+    describe('renderTemplate with refs', () => {
+
+        it('refs should not allow to access other properties but value', () => {
+            expect(
+                () => compiler.renderTemplate(`
+                    const myRef = ref('custom');
+                    return myRef.customProp;
+                `)
+            ).toThrow('customProp is not a valid ref property. A ref only exposes a value property');
+        });
+
+        it('refs should not allow to assign other properties but value', () => {
+            expect(
+                () => compiler.renderTemplate(`
+                    const myRef = ref('custom');
+                    myRef.customProp = 'changed';
+                    return true;
+                `)
+            ).toThrow('property customProp cannot be set in a ref');
+        });
+
+    });
+
+    describe('renderTemplate with unrefs', () => {
+
+        it('trying to unref a non defined ref should not be allowed', () => {
+
+            expect(
+                () => compiler.renderTemplate(`
+                    unref('custom');
+                    return true;
+                `)
+            ).toThrow('custom is not a ref or it has been unrefed already');
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
This pull request implements two methods to work with reactive variables.

#### ref and unref

`ref` and `unref` method allows to work with reactive variables. Reactive variables are variables that can be accessed globally from any template and changing their values in any template will trigger a re-render in the tracked templates using them.

```javascript
// create a ref to a variable named name
const name = ref('name');

// Changing the value of the ref name
// This will re-evaluate any template in which ref('name') has been used
name.value = 'ElChiniNet';

// Accesing the value of the ref name
const myName = name.value;

// Remove the ref name
// This will stop any re-evaluation of this reactive variable in any template
unref('name');
```

#### !IMPORTANT
>1. A `ref` has only one property, and it is `value`. Trying to access or assign another property than value will throw an error.
>2. `unref` should be called if a `ref` has been created previously or if it has not been already _unrefed_. Trying to call `unref` in a non-existent `ref` will throw an error.