### PR TITLE
Add a new parameter to the `renderTemplate` method to send extra variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.7.0] - 2025-03-09
+
+- Add a new parameter to the `renderTemplate` method to send extra variables
+
 ## [5.6.1] - 2025-02-22
 
 - Make it possible to serialize refs without errors

--- a/README.md
+++ b/README.md
@@ -115,10 +115,15 @@ This property gets and sets the global variables that will be available in the t
 #### renderTemplate
 
 ```typescript
-renderTemplate(template: string): any
+renderTemplate(
+    template: string,
+    extraVariables?: Record<string, unknown>
+): any
 ```
 
 This method renders a `JavaScript` template and return its result. It needs a string as a parameter. Inside this string you can use [several objects and methods](#objects-and-methods-available-in-the-templates). It returns whatever the `JavaScript` code returns, because of that it is typed as `any`.
+
+This method accepts an optional second parameter with extra variables. These variables will be appended to [the global variables](#variables).
 
 #### trackTemplate
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ import {
     Scopped,
     RenderingFunction,
     HassConnection,
-    SubscriberEvent
+    SubscriberEvent,
+    Vars
 } from '@types';
 import {
     STRICT_MODE,
@@ -54,7 +55,7 @@ class HomeAssistantJavaScriptTemplatesRenderer {
 
     private _throwErrors: boolean;
     private _throwWarnings: boolean;
-    private _variables: Record<string, unknown>;
+    private _variables: Vars;
     private _autoReturn: boolean;
     private _clientSideEntitiesRegExp: RegExp;
     private _subscriptions: Map<
@@ -169,12 +170,18 @@ class HomeAssistantJavaScriptTemplatesRenderer {
         });
     }
 
-    public renderTemplate(template: string): any {
+    public renderTemplate(
+        template: string,
+        extraVariables: Vars = {}
+    ): any {
 
         try {
 
             const variables = new Map(
-                Object.entries(this._variables)
+                Object.entries({
+                    ...this._variables,
+                    ...extraVariables
+                })
             );
             const trimmedTemplate = template
                 .trim()
@@ -265,7 +272,10 @@ class HomeAssistantJavaScriptTemplatesRenderer {
 
     }
 
-    public trackTemplate(template: string, renderingFunction: RenderingFunction): () => void {
+    public trackTemplate(
+        template: string,
+        renderingFunction: RenderingFunction
+    ): () => void {
         this._scopped.cleanTracked();
         const result = this.renderTemplate(template);
         this._storeTracked(template, renderingFunction);                  
@@ -281,11 +291,11 @@ class HomeAssistantJavaScriptTemplatesRenderer {
         }   
     }
 
-    public get variables(): Record<string, unknown> {
+    public get variables(): Vars {
         return this._variables;
     }
 
-    public set variables(value: Record<string, unknown>) {
+    public set variables(value: Vars) {
         this._variables = value;
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,9 @@
+export type Vars = Record<string, unknown>;
+
 export interface Options {
     throwErrors?: boolean;
     throwWarnings?: boolean;
-    variables?: Record<string, unknown>;
+    variables?: Vars;
     autoReturn?: boolean;
 }
 
@@ -19,7 +21,7 @@ export interface Device {
 }
 
 export interface State {
-    attributes: Record<string, unknown>;
+    attributes: Vars;
     entity_id: string;
     state: string;
 }
@@ -80,7 +82,7 @@ export interface HassConnection {
     conn: {
         subscribeMessage: <T>(
             callback: (response: T) => void,
-            options: Record<string, unknown>
+            options: Vars
         ) => void;
     }
 }
@@ -124,7 +126,7 @@ export interface Scopped {
     user_is_owner: boolean;
     user_agent: string;
     // others
-    clientSideProxy: Record<string, unknown>;
+    clientSideProxy: Vars;
     // utilities
     tracked: Set<string>;
     ref(entityWatchCallback: (event: SubscriberEvent) => void, name: string, value?: unknown): Ref;


### PR DESCRIPTION
This pull request adds a second optional parameter to the `renderTemplate` method to be able to send extra variables that will be appended to the global ones.

#### renderTemplate

```typescript
renderTemplate(
    template: string,
    extraVariables?: Record<string, unknown>
): any
```

This method accepts an optional second parameter with extra variables. These variables will be appended to the global variables.