### PR TITLE
Fix subscribeMessage method return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.7.1] - 2025-03-30
+
+- Add proper type to the `subscribeMessage` method of `home-assistant-js-websocket`. It should return a promise that is resolved to a function that will cancel the subscription once called
+
 ## [5.7.0] - 2025-03-09
 
 - Add a new parameter to the `renderTemplate` method to send extra variables

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,12 +78,14 @@ export type SubscriberEvent = {
     }
 };
 
+export type CancelSubscription = () => Promise<void>;
+
 export interface HassConnection {
     conn: {
         subscribeMessage: <T>(
             callback: (response: T) => void,
             options: Vars
-        ) => void;
+        ) => Promise<CancelSubscription>;
     }
 }
 


### PR DESCRIPTION
This pull request fixes the return type of the `subscribeMessage` method of `home-assistant-js-websocket`, which [returns a promise that will resolve to a function that will cancel the subscription once called](https://github.com/home-assistant/home-assistant-js-websocket?tab=readme-ov-file#connsubscribemessagecallback-subscribemessage-options). 