### PR TITLE
Group Dependabot pull requests for Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,5 +24,9 @@ updates:
       timezone: "Europe/Amsterdam"
     commit-message:
       prefix: "[Github Actions]"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
     labels:
       - configuration


### PR DESCRIPTION
This pull request groups the Dependabot's pull-requests for Github actions.