### PR TITLE
Fix a bug and add lang variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.10.0] - 2025-07-27
+
+- Fix a bug that was impeding to use the variable `panel_url` with commas before of after it (e.g `console.log("test",panel_url)`)
+- New property available in the templates `lang` which will return the language that has been configured by the logged user
+
 ## [5.9.0] - 2025-07-13
 
 - Add a new method `state_translated` to return the translated state value of an entity

--- a/README.md
+++ b/README.md
@@ -377,6 +377,14 @@ Property to return the current Home Assistant panel URL (`window.location.pathna
 panel_url
 ```
 
+#### lang
+
+Property to return the language that the logged user has configured in their profile.
+
+```javascript
+panel_url
+```
+
 #### ref and unref
 
 `ref` and `unref` method allows to work with reactive variables. Reactive variables are variables that can be accessed globally from any template and changing their values in any template will trigger a re-render in the tracked templates using them.

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,11 +12,13 @@ export enum ATTRIBUTES {
 }
 
 export enum CLIENT_SIDE_ENTITIES {
-    PANEL_URL = 'panel_url'
+    PANEL_URL = 'panel_url',
+    LANG = 'lang'
 }
 
 export enum EVENT {
     LOCATION_CHANGED = 'location-changed',
+    TRANSLATIONS_UPDATED = 'translations-updated',
     POPSTATE = 'popstate',
     SUBSCRIBE_EVENTS = 'subscribe_events',
     STATE_CHANGE_EVENT = 'state_changed'

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ class HomeAssistantJavaScriptTemplatesRenderer {
             >
         >();
         this._clientSideEntitiesRegExp = new RegExp(
-            `(^|[ \\?(+:\\{\\[><])(${Object.values(CLIENT_SIDE_ENTITIES).join('|')})($|[ \\?)+:\\}\\]><.])`,
+            `(^|[ \\?(+:\\{\\[><,])(${Object.values(CLIENT_SIDE_ENTITIES).join('|')})($|[ \\?)+:\\}\\]><.,])`,
             'gm'
         );
 
@@ -51,6 +51,7 @@ class HomeAssistantJavaScriptTemplatesRenderer {
         );
         this._watchForPanelUrlChange();
         this._watchForEntitiesChange();
+        this._watchForLanguageChange();
     }
 
     private _throwErrors: boolean;
@@ -78,7 +79,7 @@ class HomeAssistantJavaScriptTemplatesRenderer {
     }
 
     private _watchForPanelUrlChange() {
-        window.addEventListener(EVENT.LOCATION_CHANGED, (event: CustomEvent): void => {
+        window.addEventListener(EVENT.LOCATION_CHANGED, (): void => {
             this._panelUrlWatchCallback();
         });
         window.addEventListener(EVENT.POPSTATE, () => {
@@ -104,6 +105,14 @@ class HomeAssistantJavaScriptTemplatesRenderer {
                 );
             });
 	}
+
+    private _watchForLanguageChange() {
+        window.addEventListener(EVENT.TRANSLATIONS_UPDATED, () => {
+            if (this._subscriptions.has(CLIENT_SIDE_ENTITIES.LANG)) {
+                this._executeRenderingFunctions(CLIENT_SIDE_ENTITIES.LANG);
+            }
+        });
+    }
 
 	private _entityWatchCallback(event: SubscriberEvent) {        
 		if (this._subscriptions.size) {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -425,9 +425,14 @@ export function createScoppedFunctions(
             {},
             {
                 get(__target, property: string) {
-                    if (property === CLIENT_SIDE_ENTITIES.PANEL_URL) {
-                        trackClientSideEntity(CLIENT_SIDE_ENTITIES.PANEL_URL);
-                        return location.pathname;
+                    if (Object.values<string>(CLIENT_SIDE_ENTITIES).includes(property)) {
+                        trackClientSideEntity(property);
+                    }
+                    switch (property) {
+                        case CLIENT_SIDE_ENTITIES.PANEL_URL:
+                            return location.pathname;
+                        case CLIENT_SIDE_ENTITIES.LANG:
+                            return ha.hass.language;
                     }
                     if(throwWarnings) {
                         console.warn(`clientSideProxy should only be used to access these variables: ${Object.values(CLIENT_SIDE_ENTITIES).join(', ')}`);

--- a/tests/03 - basic-templates.test.ts
+++ b/tests/03 - basic-templates.test.ts
@@ -733,4 +733,12 @@ describe('Basic templates tests', () => {
 
     });
 
+    describe('lang', () => {
+
+        it('lang should return the language in the hass object', () => {
+            expect(compiler.renderTemplate('lang')).toBe('en');
+        });
+
+    });
+
 });

--- a/tests/07 - entities-change.test.ts
+++ b/tests/07 - entities-change.test.ts
@@ -83,6 +83,25 @@ describe('promise instance', () => {
         expect(renderingFunction).toHaveBeenNthCalledWith(3, "yes");
     });
 
+    it('tracking a template with lang should call the rendering function when the event translations-updated is triggered', () => {
+        const renderingFunction = jest.fn();
+        renderer.trackTemplate(
+            `
+                return lang === "es"
+                    ? "sí"
+                    : "yes"
+            `,
+            renderingFunction
+        );
+        expect(renderingFunction).toHaveBeenNthCalledWith(1, "yes");
+        window.dispatchEvent(new Event(EVENT.TRANSLATIONS_UPDATED));
+        expect(renderingFunction).toHaveBeenNthCalledWith(2, "yes");
+        hassClone.language = 'es';
+        window.dispatchEvent(new Event(EVENT.TRANSLATIONS_UPDATED));
+        expect(renderingFunction).toHaveBeenNthCalledWith(3, "sí");
+        
+    });
+
     it('tracking the same template with multiple fucntions should call all of them', async () => {
         const renderingFunction1 = jest.fn();
         const renderingFunction2 = jest.fn();

--- a/tests/09 - error-templates.test.ts
+++ b/tests/09 - error-templates.test.ts
@@ -204,7 +204,7 @@ describe('Templates with errors', () => {
             expect(
                 compiler.renderTemplate('return clientSide.non_existent')
             ).toBe(undefined);
-            expect(consoleWarnMock).toHaveBeenCalledWith('clientSideProxy should only be used to access these variables: panel_url');
+            expect(consoleWarnMock).toHaveBeenCalledWith('clientSideProxy should only be used to access these variables: panel_url, lang');
         });
 
     });


### PR DESCRIPTION
This pull request brings these changes:

### New variable lang

This variable returns the language configured by the current logged user and the templates using it will be re-evaluated if the language is changed in the user profile.

### Bug fixed

A bug that was impeding the variable `panel_url` to be used with a comma before or after it (e.g. `console.log("test",panel_url)`) was fixed in this pull request.