### PR TITLE
Restore patchedDependencies to pnpm-worksapapce.yaml file

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,10 +60,5 @@
   },
   "dependencies": {
     "get-promisable-result": "^1.0.1"
-  },
-  "pnpm": {
-    "patchedDependencies": {
-      "jsdom": "patches/jsdom.patch"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+patchedDependencies:
+  jsdom: patches/jsdom.patch
+packages:
+  - .


### PR DESCRIPTION
Revert the change of moving the `patchedDependencies` field to the `pnpm-worksapapce.yaml` file because it fixed [the dependabot error](https://github.com/elchininet/home-assistant-javascript-templates/pull/129) but it provoked that the pipelines of the pull rquests fail becase of this error:

```bash
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "patchedDependencies" configuration doesn't match the value found in the lockfile
```

The trick of an empty `packages` filed has been used instead to see if it fixes the issue.